### PR TITLE
Improve the configuration for decoding datasets with staggered grid

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,42 @@
 What's new
 ##########
 
+0.4.1 (2021-09-01)
+==================
+
+New features
+------------
+- :meth:`xoa.cf.CFSpecs.decode` better supports staggered grids.
+- :meth:`xoa.cf.CFSpecs.search_dim` supports generic names in addition
+  to dimension types as second argument.
+- Add the :meth:`xoa.cf.CFSpecs.match_dim` method to check if a given
+  dimension name is known.
+- Add the :meth:`~xoa.cf.CFSpecs.reloc` and :meth:`~xoa.cf.CFSpecs.to_loc` methods
+  to :class:`xoa.cf.CFSpecs` for quickly changing the staggered grid indicators
+  in names.
+- Add the :meth:`xoa.cf.SGLocator.add_loc` method to quickly change the location
+  markers in a data array.
+
+Breaking changes
+----------------
+- :func:`xoa.coords.get_dims` is renamed to func:`xoa.coords.get_cf_dims`.
+- The `name` argument of :class:`xoa.cf.CFSpecs` methods is renamed to `cf_name`,
+  and the `dim_type(s)` argument is renamed to `cf_arg(s)`.
+- :meth:`xoa.cf.SGLocator.get_location` is renamed to
+  :meth:`~xoa.cf.SGLocator.get_loc_from_da` and the :meth:`~xoa.cf.SGLocator.get_loc` is added.
+
+Deprecations
+------------
+
+Bug fixes
+---------
+- Fix the output formatting of :func:`xoa.grid.dz2depth`.
+
+Documentation
+-------------
+- The :ref:`uses.cf` section and :ref:`sphx_glr_examples_plot_hycom_gdp.py` example
+  are adapted to reflect changes.
+
 
 v0.3.1 (2021-05-21)
 ===================

--- a/doc/uses.cf.rst
+++ b/doc/uses.cf.rst
@@ -347,7 +347,6 @@ like ``"lon"``.
 .. ipython:: python
 
     cfspecs.format_coord(lon, "lon")
-    cfspecs.format_coord(lon, "lon", loc="rho")
     cfspecs.format_data_var(temp, "temp")
 
 **Auto-formatting:**
@@ -751,3 +750,56 @@ Let's **re-encode** it!
     dse
 
 Et voilà !
+
+.. _uses.cf.hycom:
+
+Example: decoding and merging Hycom splitted outputs
+====================================================
+
+At Shom, the Hycom model outputs are splitted into separate files, one for each variable.
+Conflicts may occur when using variables that are not at the same staggered grid location,
+since all variables are stored with dimensions ``(y, x)`` and ``lon`` and ``lat``
+coordinates, all with the same name.
+To avoid this problem, the horizontal dimensions and coordinates of
+staggered variables are renamed to indicate their location.
+
+Here are the specs to take care of the staggered grid indicators in the names:
+
+.. literalinclude:: ../xoa/_samples/hycom.cfg
+    :language: ini
+
+Note the ``add_coords_loc`` sections.
+Location is not added to the ``u`` and ``v`` variables
+but to their dimensions and coordinates.
+
+Register them:
+
+.. ipython:: python
+
+    @suppress
+    import xoa, xoa.cf
+    xoa.cf.register_cf_specs(xoa.get_data_sample("hycom.cfg"))
+    xoa.cf.is_registered_cf_specs("hycom")
+
+Overview of the U dataset:
+
+.. ipython:: python
+
+    dsu = xoa.open_data_sample("hycom.gdp.u.nc")
+    dsu
+
+Decoding:
+
+.. ipython:: python
+
+    dsu = dsu.xoa.decode()
+    dsu
+
+Now we can read, decode and merge all files without any conflict:
+
+.. ipython:: python
+
+    dsv = xoa.open_data_sample("hycom.gdp.u.nc").xoa.decode()
+    dsh = xoa.open_data_sample("hycom.gdp.h.nc").xoa.decode()
+    ds = xr.merge([dsu, dsv, dsh])
+    ds

--- a/xoa/__init__.py
+++ b/xoa/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-xarray-base ocean analysis library
+xarray-based ocean analysis library
 
 The successor of Vacumm.
 """

--- a/xoa/_samples/croco.cfg
+++ b/xoa/_samples/croco.cfg
@@ -64,3 +64,7 @@ type=sigma
     name=eta
     search_order=n
     standard_name=y_grid_index
+
+    [[sig]]
+    name=s
+    add_loc=True

--- a/xoa/_samples/hycom.cfg
+++ b/xoa/_samples/hycom.cfg
@@ -2,7 +2,7 @@
 name=hycom
 
     [[attrs]]
-    nsigma = "[0-9]"
+    nsigma = "[0-9]?"
 
 [vertical]
 positive=down
@@ -10,8 +10,25 @@ type=dz
 
 [data_vars]
 
+    [[u]]
+    loc=u
+        [[[add_coords_loc]]]
+        lon=True
+        lat=True
+        x=True
+        y=True
+
+    [[v]]
+    loc=v
+        [[[add_coords_loc]]]
+        lon=True
+        lat=True
+        x=True
+        y=True
+
     [[bathy]]
     name=bathymetry
+    add_loc=True
 
     [[dz]]
     name=h

--- a/xoa/cf.cfg
+++ b/xoa/cf.cfg
@@ -1024,10 +1024,10 @@ name=generic
     # Physical
 
     [[lon]]
-    alt_names = longitude,nav_lon
+    alt_names = longitude,nav_lon,longitudes
     search_order = snu
         [[[attrs]]]
-        standard_name = longitude,longitudes
+        standard_name = longitude
         long_name = Longitude
         units = degrees_east,degree_east,degree_e,degrees_e,degreee,degreese
         axis = X

--- a/xoa/cf.ini
+++ b/xoa/cf.ini
@@ -12,7 +12,7 @@ valid_locations=strings(default=None)
 
     [[properties]]  # Shortcut accessor properties
     coords=strings(default=list(lon,lat,depth,sig,level,altitude,time,forecast)) # coord names that are added as shortcut properties
-    data_vars=strings(default=list(temp,sal,u,v,bathy))  # data_var names that are added as shortcut properties
+    data_vars=strings(default=list(temp,sal,u,v,bathy,ssh))  # data_var names that are added as shortcut properties
 
 
 [vertical] # Vertical coordinate system
@@ -30,7 +30,17 @@ type=option('sigma','z','layer','dz','auto',None,default=None) # layer=dz, auto=
     inherit=string(default=None)
     squeeze=strings(default=None)
     search_order=string(default=sn)
+    loc=string(default=None)
     add_loc=boolean(default=False)
+
+        [[[add_coords_loc]]]
+        __many__=boolstr(default=True)
+
+#        [[[add_loc_sec]]]
+#        data_var=boolean(default=False)
+#
+#            [[[[coords]]]]
+#            __many__=boolstr(default=None)
 
         [[[attrs]]]
         long_name=strings(default=list())
@@ -51,7 +61,17 @@ type=option('sigma','z','layer','dz','auto',None,default=None) # layer=dz, auto=
     alt_names=strings(default=list())
     inherit=string(default=None)
     search_order=string(default=ns)
-    add_loc=boolean(default=True)
+    loc=string(default=None)
+    add_loc=boolean(default=None)
+
+        [[[add_coords_loc]]]
+        __many__=boolstr(default=True)
+
+#        [[[add_loc_sec]]]
+#        coord=boolean(default=None)
+#
+#            [[[[coords]]]]
+#            __many__=boolean(default=None)
 
         [[[attrs]]]
         long_name=strings(default=list())

--- a/xoa/cf.py
+++ b/xoa/cf.py
@@ -32,7 +32,7 @@ import copy
 
 import appdirs
 
-from .__init__ import XoaError, xoa_warn, get_option
+from .__init__ import XoaError, xoa_warn, get_option, __version__
 from .misc import dict_merge, match_string, ERRORS, Choices
 
 _THISDIR = os.path.dirname(__file__)
@@ -59,15 +59,17 @@ _CF_DICT_MERGE_KWARGS = dict(
     skipempty=False,
     overwriteempty=True,
     mergetuples=True,
-    unique=True
+    unique=True,
 )
 
 ATTRS_PATCH_MODE = Choices(
-    {'fill': 'do not erase existing attributes, just fill missing ones',
-     'replace': 'replace existing attributes'},
+    {
+        'fill': 'do not erase existing attributes, just fill missing ones',
+        'replace': 'replace existing attributes',
+    },
     parameter="mode",
-    description="policy for patching existing attributes"
-    )
+    description="policy for patching existing attributes",
+)
 
 
 class XoaCFError(XoaError):
@@ -76,24 +78,23 @@ class XoaCFError(XoaError):
 
 def _get_cache_():
     from . import cf
+
     if not hasattr(cf, "_CF_CACHE"):
         cf._CF_CACHE = {
-            "current": None,     # current active specs
-            "default": None,     # default xoa specs
+            "current": None,  # current active specs
+            "default": None,  # default xoa specs
             "loaded_dicts": {},  # for pure caching of dicts by key
-            "registered": []     # for registration and matching purpose
+            "registered": [],  # for registration and matching purpose
         }
-    return  cf._CF_CACHE
+    return cf._CF_CACHE
 
 
-def _compile_sg_match_(re_match, attrs, formats, root_patterns,
-                       location_pattern):
+def _compile_sg_match_(re_match, attrs, formats, root_patterns, location_pattern):
     for attr in attrs:
         root_pattern = root_patterns[attr]
         re_match[attr] = re.compile(
             formats[attr].format(
-                root=rf"(?P<root>{root_pattern})",
-                loc=rf"(?P<loc>{location_pattern})"
+                root=rf"(?P<root>{root_pattern})", loc=rf"(?P<loc>{location_pattern})"
             ),
             re.I,
         ).match
@@ -110,6 +111,7 @@ class SGLocator(object):
     valid_locations: list(str), None
         Valid location strings that are used when parsing
     """
+
     valid_attrs = ("name", "standard_name", "long_name")
 
     formats = {
@@ -118,17 +120,12 @@ class SGLocator(object):
         "long_name": "{root} at {loc} location",
     }
 
-    root_patterns = {
-        "name": r"\w+",
-        "standard_name": r"\w+",
-        "long_name": r"[\w ]+"
-        }
+    root_patterns = {"name": r"\w+", "standard_name": r"\w+", "long_name": r"[\w ]+"}
 
     location_pattern = "[a-z]+"
 
     re_match = {}
-    _compile_sg_match_(re_match, valid_attrs, formats, root_patterns,
-                       location_pattern)
+    _compile_sg_match_(re_match, valid_attrs, formats, root_patterns, location_pattern)
 
     def __init__(self, name_format=None, valid_locations=None):
 
@@ -145,20 +142,24 @@ class SGLocator(object):
         if name_format:
             for pat in ("{root}", "{loc}"):
                 if pat not in name_format:
-                    raise XoaCFError("name_format must contain strings "
-                                     "{root} and {loc}: "+name_format)
+                    raise XoaCFError(
+                        "name_format must contain strings " "{root} and {loc}: " + name_format
+                    )
             if len(name_format) == 10:
-                xoa_warn('No separator found in "name_format" and '
-                         'and no "valid_locations" specified: '
-                         f'{name_format}. This leads to ambiguity during '
-                         'regular expression parsing.')
+                xoa_warn(
+                    'No separator found in "name_format" and '
+                    'and no "valid_locations" specified: '
+                    f'{name_format}. This leads to ambiguity during '
+                    'regular expression parsing.'
+                )
             self.formats["name"] = name_format
             to_recompile.add("name")
         if self.valid_locations:
             self.location_pattern = "|".join(self.valid_locations)
             to_recompile.update(("name", "standard_name", "long_name"))
-        _compile_sg_match_(self.re_match, to_recompile, self.formats,
-                           self.root_patterns, self.location_pattern)
+        _compile_sg_match_(
+            self.re_match, to_recompile, self.formats, self.root_patterns, self.location_pattern
+        )
 
     def parse_attr(self, attr, value):
         """Parse an attribute string to get its root and location
@@ -197,13 +198,18 @@ class SGLocator(object):
             return value, None
         return m.group("root"), m.group("loc").lower()
 
-    def get_location(self, da):
-        """Parse a data array name and attributes to find location
+    @ERRORS.format_method_docstring
+    def get_loc(self, name=None, attrs=None, errors="warn"):
+        """Parse name and attributes to find a unique location
 
         Parameters
         ----------
-        da: xarray.DataArray
-            Data array to scan
+        name: None, str
+            Name to parse
+        attrs: None, dict
+            Dict with `standard_name` and/or `long_name` attributes.
+        {errors}
+
 
         Return
         ------
@@ -217,39 +223,106 @@ class SGLocator(object):
             Thus, this method method is a way to check location consistency.
         """
         loc = None
+        errors = ERRORS[errors]
         src = []
 
         # Name
-        if da.name:
-            loc = self.parse_attr("name", da.name)[1]
+        if name:
+            loc = self.parse_attr("name", name)[1]
             src.append("name")
+        if not attrs:
+            return loc
 
         # Standard name
-        if "standard_name" in da.attrs:
-            loc_ = self.parse_attr("standard_name", da.standard_name)[1]
+        if "standard_name" in attrs and attrs["standard_name"]:
+            standard_name = attrs["standard_name"]
+            if isinstance(standard_name, list):
+                standard_name = standard_name[0]
+            loc_ = self.parse_attr("standard_name", standard_name)[1]
             if loc_:
-                if loc and loc_ != loc:
-                    raise XoaCFError(
-                        "The location parsed from standard_name attribute "
-                        f"[{loc_}] conflicts the location parsed from the "
-                        f"name [{loc}]")
-                else:
+                if not loc or loc_ == loc:
                     loc = loc_
                     src.append("standard_name")
+                elif errors != "ignore":
+                    msg = (
+                        "The location parsed from standard_name attribute "
+                        f"[{loc_}] conflicts the location parsed from the "
+                        f"name [{loc}]"
+                    )
+                    if errors == "raise":
+                        raise XoaCFError(msg)
+                    else:
+                        xoa_warn(msg)
 
         # Long name
-        if "long_name" in da.attrs:
-            loc_ = self.parse_attr("long_name", da.long_name)[1]
+        if "long_name" in attrs and attrs["long_name"]:
+            long_name = attrs["long_name"]
+            if isinstance(long_name, list):
+                long_name = long_name[0]
+            loc_ = self.parse_attr("long_name", long_name)[1]
             if loc_:
-                if loc and loc_ != loc:
+                if not loc or loc_ == loc:
+                    loc = loc_
+                elif errors != "ignore":
                     src = ' and '.join(src)
-                    raise XoaCFError(
+                    msg = (
                         "The location parsed from long_name attribute "
                         f"[{loc_}] conflicts the location parsed from the "
-                        f"{src} [{loc}]")
-                else:
-                    loc = loc_
+                        f"{src} [{loc}]"
+                    )
+                    if errors == "raise":
+                        raise XoaCFError(msg)
+                    else:
+                        xoa_warn(msg)
 
+        return loc
+
+    @ERRORS.format_method_docstring
+    def get_loc_from_da(self, da, errors="warn"):
+        """Parse a data array name and attributes to find a unique location
+
+        Parameters
+        ----------
+        da: xarray.DataArray
+            Data array to scan
+        {errors}
+
+        Return
+        ------
+        None, str
+            ``None`` if no location is found, else the corresponding string
+
+        Raises
+        ------
+        XoaCFError
+            When locations parsed from name and attributes are conflicting.
+            Thus, this method method is a way to check location consistency.
+        """
+        return self.get_loc(name=da.name, attrs=da.attrs, errors=errors)
+
+    def parse_loc_arg(self, loc):
+        """Parse the location argument
+
+        Return values as function of input values:
+
+            * `None`: None, True, "any"
+            * `False`: `False`, ""
+            * str: str
+        """
+        if loc is None or loc is True or loc == "any":
+            return
+        if loc is False or loc == "":
+            return False
+        if not isinstance(loc, str):
+            raise XoaCFError(
+                'Invalid loc argument. Must one of: '
+                'None, Trye, "any", False, "" or a location string'
+            )
+        if self.valid_locations is not None and loc not in self.valid_locations:
+            raise XoaCFError(
+                f'Location "{loc}" is not recognised by the currents specifications. '
+                'Registered locations are: ' + ', '.join(self.valid_locations)
+            )
         return loc
 
     def match_attr(self, attr, value, root, loc=None):
@@ -276,9 +349,10 @@ class SGLocator(object):
         root = root.lower()
         if vroot.lower() != root:
             return False
-        if loc is None or loc == "any":  # any loc
+        loc = self.parse_loc_arg(loc)
+        if loc is None:  # any loc
             return True
-        if not loc:  # not loc explicit
+        if not loc:  # explicit no loc
             return vloc is None
         return vloc in loc  # one of these locs
 
@@ -293,7 +367,7 @@ class SGLocator(object):
             Current attribute value. It is parsed to get current ``root``.
         loc: {True, None}, str, {False, ""}
             If None, location is left unchanged;
-            if a str, it is set;
+            if a non empty str, it is set;
             else, it is removed.
         standardize: bool
             If True, standardize ``root`` and ``loc`` values.
@@ -326,19 +400,25 @@ class SGLocator(object):
                 root = root.replace(" ", "_")
                 if attr == "standard_name":
                     root = root.lower()
-        if (
-            loc
-            and self.valid_locations
-            and loc.lower() not in self.valid_locations
-        ):
-            raise XoaCFError(
-                "Invalid location: {}. Please one use of: {}.".format(
-                    loc, ', '.join(self.valid_locations))
-            )
-        elif loc is False or loc == '':
-            ploc = None
-        elif loc is True or loc is None:
+        loc = self.parse_loc_arg(loc)
+        if loc is False:
+            return root
+            # loc = None
+        if loc is None:
             loc = ploc
+        # if (
+        #     loc
+        #     and self.valid_locations
+        #     and loc.lower() not in self.valid_locations
+        # ):
+        #     raise XoaCFError(
+        #         "Invalid location: {}. Please one use of: {}.".format(
+        #             loc, ', '.join(self.valid_locations))
+        #     )
+        # elif loc is False or loc == '':
+        #     ploc = None
+        # elif loc is True or loc is None:
+        #     loc = ploc
         loc = loc or ploc
         if not loc:
             return root
@@ -384,11 +464,9 @@ class SGLocator(object):
         for attr, value in attrs.items():
             if attr in self.valid_attrs and attr != 'name':
                 if isinstance(value, list):
-                    value = [self.format_attr(
-                        attr, v, loc, standardize=standardize) for v in value]
+                    value = [self.format_attr(attr, v, loc, standardize=standardize) for v in value]
                 else:
-                    value = self.format_attr(
-                        attr, value, loc, standardize=standardize)
+                    value = self.format_attr(attr, value, loc, standardize=standardize)
                 attrs[attr] = value
         return attrs
 
@@ -431,7 +509,8 @@ class SGLocator(object):
         if value1 is None:
             return self.format_attr(attr, value0, loc, standardize=standardize)
 
-        if loc in (None, "any"):
+        loc = self.parse_loc_arg(loc)
+        if loc is None:
             loc0 = self.parse_attr(attr, value0)[1]
             loc1 = self.parse_attr(attr, value1)[1]
             if loc1 is not None:
@@ -440,8 +519,7 @@ class SGLocator(object):
                 loc = loc0
         return self.format_attr(attr, value1, loc, standardize=standardize)
 
-    def patch_attrs(self, attrs, patch, loc=None, standardize=True,
-                    replace=False):
+    def patch_attrs(self, attrs, patch, loc=None, standardize=True, replace=False):
         """Patch a dict of attribute with another dict taking care of loc
 
         Parameters
@@ -471,8 +549,7 @@ class SGLocator(object):
         # Reloc if needed
         attrs = attrs.copy()
         if attrs:
-            attrs.update(self.format_attrs(
-                attrs, loc, standardize=standardize))
+            attrs.update(self.format_attrs(attrs, loc, standardize=standardize))
 
         # Loop patching on attributes
         for attr, value in patch.items():
@@ -488,8 +565,7 @@ class SGLocator(object):
                 if isinstance(value, list):
                     if attr in attrs:
                         for val in value:
-                            if self.match_attr(
-                                    attr, attrs[attr], val, loc=None):
+                            if self.match_attr(attr, attrs[attr], val, loc=None):
                                 value = attrs[attr]  # don't change, it's ok
                                 break
                         else:
@@ -499,8 +575,8 @@ class SGLocator(object):
 
                 # Location
                 value = self.merge_attr(
-                    attr, attrs.get(attr, None), value, loc,
-                    standardize=standardize)
+                    attr, attrs.get(attr, None), value, loc, standardize=standardize
+                )
 
             if value is not None:
                 attrs[attr] = value
@@ -508,17 +584,26 @@ class SGLocator(object):
         return attrs
 
     def format_dataarray(
-        self, da, loc=None, standardize=True, name=None, attrs=None,
-        rename=True, copy=True, replace_attrs=False, add_loc_to_name=True
+        self,
+        da,
+        loc=None,
+        standardize=True,
+        name=None,
+        attrs=None,
+        rename=True,
+        copy=True,
+        replace_attrs=False,
+        add_loc_to_name=True,
+        add_loc_to_attrs=True,
     ):
         """Format name and attributes of a copy of DataArray
 
         Parameters
         ----------
         da: xarray.DataArray
-        loc: {True, None}, letter, {False, ""}
+        loc: {True, None}, str, {False, ""}
             If None, location is left unchanged;
-            if a letter, it is set;
+            if a string, it is set;
             else, it is removed.
         standardize: bool
             If True, standardize ``root`` and ``loc`` values.
@@ -550,27 +635,53 @@ class SGLocator(object):
         if copy:
             da = da.copy()
 
+        # Location argument
+        loc = self.parse_loc_arg(loc)  # specified
+        if loc is None:
+            loc0 = self.get_loc_from_da(da)  # parsed from
+            loc1 = self.get_loc(name=name, attrs=attrs)  # parsed from specs
+            loc = loc0 if loc1 is None else loc1
+
         # Attributes
+        kwloc = {"loc": loc if add_loc_to_attrs else False}
         if attrs:
-            da.attrs.update(self.patch_attrs(
-                da.attrs, attrs, loc, standardize=standardize,
-                replace=replace_attrs))
+            da.attrs.update(
+                self.patch_attrs(
+                    da.attrs, attrs, standardize=standardize, replace=replace_attrs, **kwloc
+                )
+            )
         else:
-            da.attrs.update(self.format_attrs(
-                da.attrs, loc, standardize=standardize))
+            da.attrs.update(self.format_attrs(da.attrs, standardize=standardize, **kwloc))
 
         # Name
-        if rename or da.name is None:
-            kw = {"loc": loc} if add_loc_to_name else {}
-            da.name = self.merge_attr("name", da.name, name, **kw)
+        if rename:
+            kwloc = {"loc": loc if add_loc_to_name else False}
+            if da.name:  # change the name
+                da.name = self.merge_attr("name", da.name, name, **kwloc)
+            else:  # set it
+                da.name = self.format_attr("name", name, **kwloc)
 
-        # Check location consistency
-        if loc is None or loc == "any" or loc is True:
-            loc = self.get_location(da)
-            if loc:
-                da = self.format_dataarray(da, loc=loc, rename=True, replace_attrs=True)
+        # # Check location consistency
+        # loc = self.parse_loc_arg(loc)
+        # if loc is None:
+        #     loc = self.get_loc(da)
+        #     if loc:
+        #         da = self.format_dataarray(
+        #             da, loc=loc, rename=True, replace_attrs=True,
+        #             add_loc_to_name=add_loc_to_name)
 
         return da
+
+    def add_loc(self, da, loc, to_name=True, to_attrs=True):
+        """A shortcut to :meth:`format_dataarray` to update `da` with loc without copy"""
+        return self.format_dataarray(
+            da,
+            loc,
+            copy=False,
+            replace_attrs=True,
+            add_loc_to_name=to_name,
+            add_loc_to_attrs=to_attrs,
+        )
 
 
 def _solve_rename_conflicts_(rename_args):
@@ -578,11 +689,15 @@ def _solve_rename_conflicts_(rename_args):
     used = {}
     for old_name in list(rename_args):
         new_name = rename_args[old_name]
+        if old_name == new_name:
+            del rename_args[old_name]
+            continue
         if new_name in used:
             del rename_args[old_name]
             xoa_warn(
                 f"Cannot rename {old_name} to {new_name} since "
-                f"{used[new_name]} will also be renamed to {new_name}. Skipping...")
+                f"{used[new_name]} will also be renamed to {new_name}. Skipping..."
+            )
         else:
             used[new_name] = old_name
     return rename_args
@@ -664,15 +779,16 @@ class CFSpecs(object):
         # Get it from cache if from str or CFSpecs with registration name
         if cache is None:
             cache = get_option("cf.cache")
-        cache = cache and ((isinstance(cfg, str) and '\n' not in cfg) or
-                           (isinstance(cfg, dict) and "register" in cfg and
-                            cfg["register"]["name"]))
+        cache = cache and (
+            (isinstance(cfg, str) and '\n' not in cfg)
+            or (isinstance(cfg, dict) and "register" in cfg and cfg["register"]["name"])
+        )
         if cache:
 
             # Init cache
             if isinstance(cfg, str):
                 cache_key = cfg
-            elif (isinstance(cfg, dict) and "register" in cfg and cfg["register"]["name"]):
+            elif isinstance(cfg, dict) and "register" in cfg and cfg["register"]["name"]:
                 cache_key = cfg["register"]["name"]
             cf_cache = _get_cache_()
             if cache_key in cf_cache["loaded_dicts"]:
@@ -793,9 +909,7 @@ class CFSpecs(object):
         if name == "dims":
             return self._dict['dims']
         raise AttributeError(
-            "'{}' object has no attribute '{}'".format(
-                self.__class__.__name__, name
-            )
+            "'{}' object has no attribute '{}'".format(self.__class__.__name__, name)
         )
 
     @property
@@ -898,9 +1012,7 @@ class CFSpecs(object):
                 from_cat, from_name = from_name.split(":")[:2]
             else:
                 from_cat = category
-            assert (
-                from_cat != category or name != from_name
-            ), "Cannot inherit cf specs from it self"
+            assert from_cat != category or name != from_name, "Cannot inherit cf specs from it self"
 
             # Parents must be already processed
             for item in self._process_entry_(from_cat, from_name):
@@ -919,8 +1031,10 @@ class CFSpecs(object):
                 for key in list(specs.keys()):
                     # print(self._cfgspecs[category])
                     # print(self._cfgspecs[from_cat])
-                    if (key not in self._cfgspecs[category]["__many__"] and
-                            key in self._cfgspecs[from_cat]["__many__"]):
+                    if (
+                        key not in self._cfgspecs[category]["__many__"]
+                        and key in self._cfgspecs[from_cat]["__many__"]
+                    ):
                         del specs[key]
 
             # Switch off inheritance now
@@ -959,23 +1073,242 @@ class CFSpecs(object):
 
         See also
         --------
-        SGLocator.get_location
+        SGLocator.get_loc
         """
-        return self.sglocator.get_location(da)
+        return self.sglocator.get_loc(da)
 
     get_location = get_loc
 
-    def format_coord(self, da, name=None, loc=None, copy=True,
-                     standardize=True, rename=True, rename_dim=True,
-                     specialize=False, attrs=True, replace_attrs=False,
-                     add_loc_to_name=None, rename_dims=True):
+    def get_loc_mapping(self, obj, cf_names=None, categories=["coords", "data_vars"]):
+        """Associate a location to each identified variables, coordinates and dimensions of obj
+
+        Parameters
+        ----------
+        obj: xarray.DataArray, xarray.Dataset
+        cf_names: dict, None
+            Dict with names as keys and generic CF names as values.
+            If not provided, :meth:`match` is used to guess CF names.
+
+        Return
+        ------
+        dict
+            Keys are item names and values are location.
+            This dict is also stored in the `cf_locs` key of the `encoding`
+            attribute of `obj`.
+        """
+        # # Check cache
+        # if "cf_locs" in obj.encoding:
+        #     return obj.encoding["cf_locs"]
+
+        locations = {}
+        das = obj.values() if hasattr(obj, "data_vars") else [obj]
+
+        def check_coords(da, specs, locations):
+            """Scan the add_coords_loc section and the coordinates and dimensions"""
+            for cf_coord_name, coord_loc in specs["add_coords_loc"].items():
+                if self.coords[cf_coord_name]["attrs"]["axis"].lower() not in 'xyz':
+                    continue
+
+                loc = specs["loc"] if coord_loc is True else coord_loc
+
+                # Coordinates
+                coord = self.search_coord(da, cf_coord_name, errors="ignore")
+                if coord is not None and locations.get(coord.name) is None:
+                    locations[coord.name] = loc
+                    continue
+
+                # Dimensions
+                dim = self.search_dim(da, cf_coord_name, errors="ignore")
+                if dim is not None and locations.get(dim) is None:
+                    locations[dim] = loc
+
+        # Loop on data vars
+        for da in das:
+            for cat in categories:
+                cf_name = cf_names.get(da.name) if cf_names else self[cat].match(da)
+                if cf_name and cf_name in self[cat]:
+                    specs = self[cat][cf_name]
+                    if specs["add_loc"] is not False:
+                        if specs["loc"] is None:  # infer from da
+                            locations[da.name] = self.sglocator.get_loc_from_da(da)
+                            if locations[da.name] is None and specs["add_loc"] is True:
+                                locations[da.name] = True
+                        else:
+                            locations[da.name] = specs["loc"]  # from config
+                    else:
+                        locations[da.name] = False
+                    check_coords(da, specs, locations)  # check coords from config
+                    break  # good category
+            else:
+                continue
+
+        # Loop on coordinates
+        for coord in obj.coords.values():
+            cf_coord_name = cf_names.get(coord.name) if cf_names else self.coords.match(coord)
+            if (cf_coord_name and
+                    (self.coords[cf_coord_name]["attrs"]["axis"] or "").lower() in 'xyz'):
+                if locations.get(coord.name) is None:
+                    if self.coords[cf_coord_name]["add_loc"] is not False:
+                        if self.coords[cf_coord_name]["loc"] is None:
+                            # infer from da
+                            locations[coord.name] = self.sglocator.get_loc_from_da(coord)
+                            if (locations[coord.name] is None and
+                                    self.coords[cf_coord_name]["add_loc"] is True):
+                                locations[coord.name] = True
+                        else:
+                            # from config
+                            locations[coord.name] = self.coords[cf_coord_name]["loc"]
+                    else:
+                        locations[coord.name] = False
+                check_coords(coord, self.coords[cf_coord_name], locations)
+
+        # Loop again on data vars: if loc is True for an datarray and loc is unique
+        # for all dims, it is set to the array too
+        for da in das:
+            if locations.get(da.name) is True:
+                loc = None
+                for dim in list(da.dims) + list(da.coords):
+                    dim_loc = locations.get(dim)
+                    if dim_loc is not None:
+                        if loc is None:
+                            loc = dim_loc
+                        elif loc != dim_loc:
+                            break  # multiple locs so no loc
+                else:
+                    locations[da.name] = loc
+
+        # # Store in encoding
+        # obj.encoding["cf_locs"] = locations
+        # for name, loc in locations.items():
+        #     if name in obj.coords or name not in obj.dims:
+        #         obj[name].encoding["cf_loc"] = loc
+
+        return locations
+
+    def _format_obj_(
+        self,
+        obj,
+        cf_names=None,
+        rename=True,
+        standardize=True,
+        format_coords=True,
+        copy=True,
+        replace_attrs=False,
+        attrs=True,
+        # loc=None, add_loc_to_name=None, add_loc_to_coord_names=None,
+        specialize=False,
+        rename_dims=True,
+        categories=["coords", "data_vars"],
+    ):
+        """Auto-format a whole xarray.Dataset
+
+        See also
+        --------
+        format_data_var
+        format_coord
+        """
+        # Copy
+        if copy:
+            obj = obj.copy()
+
+        # Init rename dict
+        rename_args = {}
+
+        # Common formatting kwargs
+        kwargs = dict(
+            copy=False,
+            rename=False,
+            replace_attrs=replace_attrs,
+            standardize=True,
+            specialize=specialize,
+        )
+
+        # Staggared grid locations
+        locations = self.get_loc_mapping(obj, cf_names=cf_names, categories=categories)
+
+        # Data arrays
+        is_dataset = hasattr(obj, "data_vars")
+        if is_dataset:  # dataset
+            data_vars = obj.values()
+        else:
+            data_vars = [obj]
+        for da in data_vars:
+            for cat in categories:
+                cf_name = cf_names.get(da.name) if cf_names else None
+                if cf_name and cf_name not in self[cat]:
+                    continue
+                new_name = self[cat].format_dataarray(
+                    da,
+                    cf_name=cf_name,
+                    attrs=attrs if isinstance(attrs, bool) else attrs.get(da.name),
+                    # format_coords=False,
+                    loc=locations.get(da.name),
+                    **kwargs,
+                )
+                if new_name:
+                    break
+            else:
+                new_name = None
+            if rename and new_name:
+                if is_dataset:
+                    rename_args[da.name] = new_name
+                else:
+                    da.name = new_name
+
+        # Coordinates
+        if format_coords:
+            for cname, cda in list(obj.coords.items()):
+                new_coord_name = self.coords.format_dataarray(
+                    cda,
+                    cf_name=cf_names.get(cname) if isinstance(cf_names, dict) else None,
+                    attrs=attrs if isinstance(attrs, bool) else attrs.get(cname, True),
+                    # related=obj,
+                    # format_coords=False,
+                    # loc=loc, add_loc_to_name=add_loc_to_coord_names,
+                    loc=locations.get(cda.name),
+                    # rename_dim=False,
+                    **kwargs,
+                )
+                if rename and new_coord_name:
+                    rename_args[cda.name] = new_coord_name
+
+        # Dimensions
+        if rename_dims:
+            rename_dims_args = self.coords.get_rename_dims_args(
+                obj, locations=locations, specialize=specialize
+            )  # , exclude=list(rename_args.keys()))
+            rename_args.update(rename_dims_args)
+
+        # Final renaming
+        if rename and rename_args:
+            _solve_rename_conflicts_(rename_args)
+            obj = obj.rename(rename_args)
+
+        return obj
+
+    def format_coord(
+        self,
+        da,
+        cf_name=None,
+        # loc=None,
+        copy=True,
+        format_coords=True,
+        standardize=True,
+        rename=True,
+        rename_dim=True,
+        specialize=False,
+        attrs=True,
+        replace_attrs=False,
+        # add_loc_to_name=None,
+        rename_dims=True,
+    ):
         """Format a coordinate array
 
         Parameters
         ----------
         da: xarray.DataArray
-        name: str, None
-            A CF name. If not provided, it guessed with :meth:`match`.
+        cf_name: str, None
+            A generic CF name. If not provided, it guessed with :meth:`match`.
         loc: str, {"any", None}, {"", False}
             - str: one of these locations
             - None or "any": any
@@ -1011,199 +1344,178 @@ class CFSpecs(object):
         --------
         CFCoordSpecs.format_dataarray
         """
-        return self.coords.format_dataarray(
-            da, name=name, loc=loc, copy=copy, standardize=standardize,
-            rename=rename, rename_dim=rename_dim,
-            replace_attrs=replace_attrs, attrs=attrs,
-            specialize=specialize, add_loc_to_name=add_loc_to_name)
+        return self._format_obj_(
+            da,
+            cf_names={da.name: cf_name},
+            copy=copy,
+            standardize=standardize,
+            rename=rename,
+            rename_dims=rename_dims,
+            format_coords=format_coords,
+            replace_attrs=replace_attrs,
+            attrs=attrs if isinstance(attrs, bool) else {da.name: attrs},
+            specialize=specialize,
+            categories=["coords"],
+        )
 
     def format_data_var(
         self,
         da,
-        name=None,
+        cf_name=None,
+        # loc=None,
+        copy=True,
         rename=True,
+        rename_dims=True,
         specialize=False,
+        format_coords=True,
         attrs=True,
         replace_attrs=False,
-        format_coords=True,
-        coords=None,
-        loc=None,
         standardize=True,
-        copy=True,
-        add_loc_to_name=None,
-        coord_add_loc_to_name=None,
-        rename_dims=True
+        # add_loc_to_name=None,
     ):
-        """Format array name and attributes according to currents CF specs
+        """Format a data_var array
 
         Parameters
         ----------
         da: xarray.DataArray
-        name: str, None
-            CF name. If None, it is guessed.
+        cf_name: str, None
+            A generic CF name. If not provided, it guessed with :meth:`match`.
         loc: str, {"any", None}, {"", False}
-
             - str: one of these locations
             - None or "any": any
             - False or '"": no location
-
         rename: bool
-            Not only format attribute, but also rename arrays,
-            thus making a copies.
+            Rename arrays
         add_loc_to_name: bool
             Add loc to the name
-        coord_add_loc_to_name: bool
-            Add loc to the coordinates name
         specialize: bool
             Does not use the CF name for renaming, but the first name
             as listed in specs, which is generally a specialized one,
             like a name adopted by specialized dataset.
-        rename_dims:
-            Also rename dimensions that are not coordinates
+        standardize: bool
+        rename_dims: bool
+            For a 1D array, rename the dimension if it has the same name
+            as the array.
+            Note that it is set to False, if ``rename`` is False.
         attrs: bool, dict
             If False, does not change attributes at all.
             If True, use Cf attributes.
             If a dict, use this dict.
         replace_attrs: bool
             Replace existing attributes?
-        format_coords: bool
-            Also format coords.
-        coords: dict, None
-            Dict whose keys are coord names, and values are CF coord names.
-            Used only if ``format_coords`` is True.
-        standardize: bool
-        copy: bool
-            Make sure to work on a copy of the array.
-            Note that a copy is always returned when ``rename`` is True.
 
         Returns
         -------
-        xarray.DataArray
-            Formatted array
+        xarray.DataArray, str, None
+            The formatted array or copy of it.
+            The CF name, given or matching, if rename if False; and None
+            if not matching.
 
         See also
         --------
         CFCoordSpecs.format_dataarray
-        CFVarSpecs.format_dataarray
         """
-        # Copy
-        if copy:
-            da = da.copy()
-
-        # Init rename dict
-        rename_args = {}
-
-        # Data var
-        for cat in "data_vars", "coords":
-            new_name = self[cat].format_dataarray(
-                da, name=name, loc=loc, standardize=standardize,
-                rename=False, copy=False, replace_attrs=replace_attrs,
-                attrs=attrs, specialize=specialize,
-                add_loc_to_name=add_loc_to_name
-            )
-            if new_name:
-                break
-        if rename and new_name:
-            da.name = new_name
-
-        # Coordinates
-        if format_coords:
-            coords = coords or {}
-            for cname, cda in list(da.coords.items()):
-                rename_args[cda.name] = self.format_coord(
-                    cda,
-                    name=coords.get(cname),
-                    loc=loc,
-                    standardize=standardize,
-                    rename=False,
-                    copy=False,
-                    replace_attrs=replace_attrs,
-                    add_loc_to_name=coord_add_loc_to_name
-                )
-
-        # Dimensions
-        if rename and rename_dims:
-            rename_dims_args = self.coords.get_rename_dims_args(
-                da, loc=loc, specialize=specialize)#, exclude=list(rename_args.keys()))
-            rename_args.update(rename_dims_args)
-
-        # Final renaming
-        if rename and rename_args:
-            _solve_rename_conflicts_(rename_args)
-            da = da.rename(rename_args)
-
-        # Return the guessed name
-        if not rename and name is None:
-            return new_name
-
-        return da
+        return self._format_obj_(
+            da,
+            cf_names={da.name: cf_name},
+            copy=copy,
+            rename=rename,
+            rename_dims=rename_dims,
+            specialize=specialize,
+            format_coords=format_coords,
+            replace_attrs=replace_attrs,
+            attrs=attrs if isinstance(attrs, bool) else {da.name: attrs},
+            standardize=standardize,
+            categories=["coords", "data_vars"],
+        )
 
     def format_dataset(
-            self, ds, loc=None, rename=True, standardize=True, format_coords=True,
-            coords=None, copy=True, replace_attrs=False, add_loc_to_name=None,
-            coord_add_loc_to_name=None, specialize=False,
-            rename_dims=True):
-        """Auto-format a whole xarray.Dataset
+        self,
+        ds,
+        cf_names=None,
+        # loc=None,
+        copy=True,
+        format_coords=True,
+        standardize=True,
+        rename=True,
+        rename_dims=True,
+        specialize=False,
+        attrs=True,
+        replace_attrs=False,
+        # add_loc_to_name=None
+    ):
+        """Format a whole dataset
+
+        Parameters
+        ----------
+        ds: xarray.Dataset
+        cf_names: dict, None
+            Dict of names as keys and generic CF names as values.
+            If not provided, CF names are guessed with :meth:`match`.
+        loc: str, {"any", None}, {"", False}
+            - str: one of these locations
+            - None or "any": any
+            - False or '"": no location
+        rename: bool
+            Rename arrays
+        add_loc_to_name: bool
+            Add loc to the name
+        specialize: bool
+            Does not use the CF name for renaming, but the first name
+            as listed in specs, which is generally a specialized one,
+            like a name adopted by specialized dataset.
+        standardize: bool
+        rename_dim: bool
+            For a 1D array, rename the dimension if it has the same name
+            as the array.
+            Note that it is set to False, if ``rename`` is False.
+        attrs: bool, dict of dict
+            If False, does not change attributes at all.
+            If True, use Cf attributes.
+            If a dict, use this dict.
+        replace_attrs: bool
+            Replace existing attributes?
+
+        Returns
+        -------
+        xarray.DataArray, str, None
+            The formatted array or copy of it.
+            The CF name, given or matching, if rename if False; and None
+            if not matching.
 
         See also
         --------
-        format_data_var
-        format_coord
+        CFCoordSpecs.format_dataarray
         """
-        # Copy
-        if copy:
-            ds = ds.copy()
+        return self._format_obj_(
+            ds,
+            cf_names=cf_names,
+            copy=copy,
+            standardize=standardize,
+            rename=rename,
+            rename_dims=rename_dims,
+            format_coords=format_coords,
+            replace_attrs=replace_attrs,
+            attrs=attrs,
+            specialize=specialize,
+            categories=["coords", "data_vars"],
+        )
 
-        # Init rename dict
-        rename_args = {}
-
-        # Data arrays
-        for name, da in list(ds.items()):
-            new_name = self.format_data_var(
-                da, loc=loc, rename=False, standardize=True,
-                format_coords=False, copy=False, replace_attrs=replace_attrs,
-                add_loc_to_name=add_loc_to_name, specialize=specialize)
-            if rename and new_name:
-                rename_args[da.name] = new_name
-
-        # Coordinates
-        if format_coords:
-            for cname, cda in list(ds.coords.items()):
-                new_name = self.format_coord(
-                    cda, loc=loc, standardize=True, rename=False,
-                    rename_dim=False, copy=False, replace_attrs=replace_attrs,
-                    add_loc_to_name=coord_add_loc_to_name, specialize=specialize)
-                if rename and new_name:
-                    rename_args[cda.name] = new_name
-
-        # Dimensions
-        if rename_dims:
-            rename_dims_args = self.coords.get_rename_dims_args(
-                ds, loc=loc, specialize=specialize)#, exclude=list(rename_args.keys()))
-            rename_args.update(rename_dims_args)
-
-        # Final renaming
-        if rename and rename_args:
-            _solve_rename_conflicts_(rename_args)
-            ds = ds.rename(rename_args)
-
-        return ds
-
-    def auto_format(self, dsa, **kwargs):
+    def auto_format(self, obj, **kwargs):
         """Rename variables and coordinates and fill their attributes
 
         See also
         --------
         encode
-        format_dataarray
+        format_data_var
         format_dataset
         fill_attrs
         """
-        if hasattr(dsa, "data_vars"):
-            return self.format_dataset(dsa, format_coords=True, **kwargs)
-        return self.format_data_var(dsa, **kwargs)
+        if hasattr(obj, "data_vars"):
+            return self.format_dataset(obj, **kwargs)
+        return self.format_data_var(obj, **kwargs)
 
-    def decode(self, dsa, **kwargs):
+    def decode(self, obj, **kwargs):
         """Auto format, infer coordinates and rename to generic names
 
         See also
@@ -1214,19 +1526,19 @@ class CFSpecs(object):
         format_dataset
         fill_attrs
         """
-        # Names and attributes
-        dsa = self.auto_format(dsa, **kwargs)
-
         # Coordinates
-        dsa = self.infer_coords(dsa)
+        obj = self.infer_coords(obj)
+
+        # Names and attributes
+        obj = self.auto_format(obj, **kwargs)
 
         # Assign cf specs
         if self.name and self in get_registered_cf_specs():
-            dsa = assign_cf_specs(dsa, self.name)
+            obj = assign_cf_specs(obj, self.name)
 
-        return dsa
+        return obj
 
-    def encode(self, dsa, **kwargs):
+    def encode(self, obj, **kwargs):
         """Same as :meth:`decode` but rename with the specialized name
 
         See also
@@ -1238,9 +1550,79 @@ class CFSpecs(object):
         fill_attrs
         """
         kwargs.setdefault("specialize", True)
-        return self.decode(dsa, **kwargs)
+        return self.decode(obj, **kwargs)
 
-    def fill_attrs(self, dsa, **kwargs):
+    def to_loc(self, obj, **locs):
+        """Set the staggered grid location for specified names
+
+        .. note:: It only changes the names, not the attributes.
+
+        Parameters
+        ----------
+        obj: xarray.Dataset, xarray.DataArray
+        locs: dict
+            **Keys are root names**, values are new locations.
+            A value of `False`, remove the location.
+            A value of `None` left it as is.
+
+        Return
+        ------
+        xarray.Dataset, xarray.DataArray
+
+        See also
+        --------
+        reloc
+        sglocator
+        SGLocator.format_attr
+        """
+        rename_args = {}
+        names = set(obj.dims).union(obj.coords)
+        if hasattr(obj, "data_vars"):
+            names = names.union(obj.data_vars)
+        for name in names:
+            if name not in rename_args:
+                root_name, old_loc = self.sglocator.parse_attr("name", name)
+                if root_name in locs and locs[root_name] is not None:
+                    rename_args[name] = self.sglocator.format_attr(
+                        "name", root_name, locs[root_name])
+        return obj.rename(rename_args)
+
+    def reloc(self, obj, **locs):
+        """Convert given staggered grid locations to other locations
+
+        .. note:: It only changes the names, not the attributes.
+
+        Parameters
+        ----------
+        obj: xarray.Dataset, xarray.DataArray
+        locs: dict
+            **Keys are locations**, values are new locations.
+            A value of `False` or `None`, remove the location.
+
+        Return
+        ------
+        xarray.Dataset, xarray.DataArray
+
+        See also
+        --------
+        to_loc
+        sglocator
+        SGLocator.format_attr
+        """
+        rename_args = {}
+        names = set(obj.dims).union(obj.coords)
+        if hasattr(obj, "data_vars"):
+            names = names.union(obj.data_vars)
+        for name in names:
+            if name not in rename_args:
+                root_name, old_loc = self.sglocator.parse_attr("name", name)
+                if old_loc and old_loc in locs:
+                    rename_args[name] = self.sglocator.format_attr(
+                        "name", root_name, locs[old_loc])
+
+        return obj.rename(rename_args)
+
+    def fill_attrs(self, obj, **kwargs):
         """Fill missing attributes of a xarray.Dataset or xarray.DataArray
 
         .. note:: It does not rename anything
@@ -1252,17 +1634,17 @@ class CFSpecs(object):
         auto_format
         """
         kwargs.update(rename=False, replace_attrs=False)
-        if hasattr(dsa, "data_vars"):
-            return self.format_dataset(dsa, format_coords=True, **kwargs)
-        return self.format_data_var(dsa, **kwargs)
+        if hasattr(obj, "data_vars"):
+            return self.format_dataset(obj, format_coords=True, **kwargs)
+        return self.format_data_var(obj, **kwargs)
 
-    def match_coord(self, da, name=None, loc="any"):
+    def match_coord(self, da, cf_name=None, loc="any"):
         """Check if an array matches a given or any coord specs
 
         Parameters
         ----------
         da: xarray.DataArray
-        name: str, dict, None
+        cf_name: str, dict, None
             Cf name.
             If None, all names are used.
             If a dict, name is interpreted as an explicit set of
@@ -1281,9 +1663,9 @@ class CFSpecs(object):
         --------
         CFCoordSpecs.match
         """
-        return self.coords.match(da, name=name, loc=loc)
+        return self.coords.match(da, cf_name=cf_name, loc=loc)
 
-    def match_data_var(self, da, name=None, loc="any"):
+    def match_data_var(self, da, cf_name=None, loc="any"):
         """Check if an array matches given or any data_var specs
 
         Parameters
@@ -1308,11 +1690,36 @@ class CFSpecs(object):
         --------
         CFVarSpecs.match
         """
-        return self.data_vars.match(da, name=name, loc=loc)
+        return self.data_vars.match(da, cf_name=cf_name, loc=loc)
+
+    def match_dim(self, dim, cf_name=None, loc=None):
+        """Check if a dimension name matches given or any coord specs
+
+        Parameters
+        ----------
+        dim: str
+            Dimension name
+        cf_name: str, None
+            Cf name.
+        loc: str, {"any", None}, {"", False}
+            - str: one of these locations
+            - None or "any": any
+            - False or '"": no location
+
+        Returns
+        -------
+        bool, str
+            True or False if name is provided, else found name or None
+
+        See also
+        --------
+        CFVarSpecs.match_from_name
+        """
+        return self.coords.match_from_name(dim, cf_name=cf_name, loc=loc)
 
     @staticmethod
     def get_category(da):
-        """Guess if a datarray belongs to data_vars or coords
+        """Guess if a dataarray belongs to data_vars or coords
 
         It belongs to coords if one of its dimensions or
         coordinates has its name.
@@ -1325,8 +1732,7 @@ class CFSpecs(object):
         -------
         str
         """
-        if da.name is not None and (da.name in da.dims or
-                                    da.name in da.coords):
+        if da.name is not None and (da.name in da.dims or da.name in da.coords):
             return "coords"
         return "data_vars"
 
@@ -1353,22 +1759,20 @@ class CFSpecs(object):
         if category != categories[0]:
             categories = categories[::-1]
         for category in categories:
-            name = self[category].match(da, loc=loc)
-            if name:
-                return category, name
+            cf_name = self[category].match(da, loc=loc)
+            if cf_name:
+                return category, cf_name
         return None, None
 
     @ERRORS.format_method_docstring
-    def search_coord(
-            self, dsa, name=None, loc="any", get="obj", single=True,
-            errors="warn"):
+    def search_coord(self, obj, cf_name=None, loc="any", get="obj", single=True, errors="warn"):
         """Search for a coord that maches given or any specs
 
         Parameters
         ----------
-        dsa: DataArray or Dataset
-        name: str, dict
-            A CF name. If not provided, all CF names are scaned.
+        obj: DataArray or Dataset
+        cf_name: str, dict
+            A generic CF name. If not provided, all CF names are scaned.
         loc: str, {{"any", None}}, {{"", False}}
             - str: one of these locations
             - None or "any": any
@@ -1398,7 +1802,7 @@ class CFSpecs(object):
             data = xr.DataArray([0, 1], dims=('foo'), coords=[lon])
             cfspecs = get_cf_specs()
             cfspecs.search_coord(data, "lon")
-            cfspecs.search_coord(data, "lon", get="name")
+            cfspecs.search_coord(data, "lon", get="cf_name")
             cfspecs.search_coord(data, "lat", errors="ignore")
 
         See also
@@ -1407,32 +1811,32 @@ class CFSpecs(object):
         CFCoordSpecs.search
         """
         return self.coords.search(
-            dsa, name=name, loc=loc, get=get, single=single, errors=errors)
+            obj, cf_name=cf_name, loc=loc, get=get, single=single, errors=errors
+        )
 
     @ERRORS.format_method_docstring
-    def search_dim(self, da, dim_type=None, loc="any", errors="ignore"):
+    def search_dim(self, da, cf_arg=None, loc="any", errors="ignore"):
         """Search for a dimension from its type
 
         Parameters
         ----------
         da: xarray.DataArray
-        dim_type: None, {{"x", "y", "z", "t", "f"}}
-            Dimension type
+        cf_arg: None, str, {{"x", "y", "z", "t", "f"}}
+            Dimension type or generic CF name
         loc:
-            Location
+            Staggered grid location
         {errors}
 
         Return
         ------
-        str, (str, str)
-            Dim name OR, (dim name, dim_type) if dim_type is None
+        None, str, dict
+            Dim name OR, dict with dim, type and cf_name keys if cf_arg is None
 
         See also
         --------
         CFCoordSpecs.search_dim
         """
-        return self.coords.search_dim(
-            da, dim_type=dim_type, loc=loc, errors=errors)
+        return self.coords.search_dim(da, cf_arg=cf_arg, loc=loc, errors=errors)
 
     @ERRORS.format_method_docstring
     def search_coord_from_dim(self, da, dim, errors="ignore"):
@@ -1456,16 +1860,14 @@ class CFSpecs(object):
         return self.coords.search_from_dim(da, dim, errors=errors)
 
     @ERRORS.format_method_docstring
-    def search_data_var(
-            self, dsa, name=None, loc="any", get="obj", single=True,
-            errors="warn"):
+    def search_data_var(self, obj, cf_name=None, loc="any", get="obj", single=True, errors="warn"):
         """Search for a data_var that maches given or any specs
 
         Parameters
         ----------
-        dsa: DataArray or Dataset
-        name: str, dict
-            A CF name. If not provided, all CF names are scaned.
+        obj: DataArray or Dataset
+        cf_name: str, dict
+            A generic CF name. If not provided, all CF names are scaned.
         loc: str, {{"any", None}}, {{"", False}}
             - str: one of these locations
             - None or "any": any
@@ -1497,7 +1899,7 @@ class CFSpecs(object):
             ds = xr.Dataset({{'foo': data}})
             cfspecs = get_cf_specs()
             cfspecs.search_data_var(ds, "temp")
-            cfspecs.search_data_var(ds, "temp", get="name")
+            cfspecs.search_data_var(ds, "temp", get="cf_name")
             cfspecs.search_data_var(ds, "sal")
 
         See also
@@ -1506,20 +1908,22 @@ class CFSpecs(object):
         CFVarSpecs.search
         """
         return self.data_vars.search(
-            dsa, name=name, loc=loc, get=get, single=single, errors=errors)
+            obj, cf_name=cf_name, loc=loc, get=get, single=single, errors=errors
+        )
 
     @ERRORS.format_method_docstring
-    def search(self, dsa, name=None, loc="any", get="obj",
-               single=True, categories=None, errors="warn"):
+    def search(
+        self, obj, cf_name=None, loc="any", get="obj", single=True, categories=None, errors="warn"
+    ):
         """Search for a dataarray with data_vars and/or coords
 
 
         Parameters
         ----------
-        dsa: xarray.DataArray, xarray.Dataset
+        obj: xarray.DataArray, xarray.Dataset
             Array or dataset to scan
-        name: str
-            Name to search for.
+        cf_name: str
+            Generic CF name to search for.
         categories: str, list, None
             Explicty categories with "coords" and "data_vars".
         {errors}
@@ -1530,8 +1934,7 @@ class CFSpecs(object):
 
         """
         if not categories:
-            categories = (self.categories if hasattr(dsa, "data_vars")
-                          else ["coords", "data_vars"])
+            categories = self.categories if hasattr(obj, "data_vars") else ["coords", "data_vars"]
         elif isinstance(categories, str):
             categories = [categories]
         else:
@@ -1540,8 +1943,9 @@ class CFSpecs(object):
         if not single:
             found = []
         for category in categories:
-            res = self[category].search(dsa, name=name, loc=loc, get=get,
-                                        single=single, errors="ignore")
+            res = self[category].search(
+                obj, cf_name=cf_name, loc=loc, get=get, single=single, errors="ignore"
+            )
             if not single:
                 res = [r for r in res if r not in found]
                 found.extend(res)
@@ -1555,29 +1959,29 @@ class CFSpecs(object):
         elif errors == "raise":
             raise XoaCFError(msg)
 
-    def get(self, dsa, name, get="obj"):
-        """A shortcut to :meth:`search` with an explicit name
+    def get(self, obj, cf_name, get="obj"):
+        """A shortcut to :meth:`search` with an explicit generic CF name
 
         A single element is searched for into all :attr:`categories`
         and errors are ignored.
         """
-        return self.search(dsa, name, errors="ignore", single=True, get=get)
+        return self.search(obj, cf_name, errors="ignore", single=True, get=get)
         # if da is None:
         #     raise XoaCFError("Search failed for the following cf name: "
         #                      + name)
         # return da
 
     @ERRORS.format_method_docstring
-    def get_dims(self, da, dim_types, allow_positional=False,
-                 positions='tzyx', errors="warn"):
+    def get_dims(self, da, cf_args, allow_positional=False, positions='tzyx', errors="warn"):
         """Get the data array dimensions names from their type
 
         Parameters
         ----------
         da: xarray.DataArray
             Array to scan
-        dim_types: str, list
-            Letters among "x", "y", "z", "t" and "f".
+        cf_args: str, list
+            Letters among "x", "y", "z", "t" and "f",
+            or generic CF names.
         allow_positional: bool
             Fall back to positional dimension of types is unkown.
         positions: str
@@ -1594,21 +1998,100 @@ class CFSpecs(object):
         CFCoordSpecs.get_dims
         """
         return self.coords.get_dims(
-            da, dim_types, allow_positional=allow_positional,
-            positions=positions, errors=errors)
+            da, cf_args, allow_positional=allow_positional, positions=positions, errors=errors
+        )
 
     def get_axis(self, coord, lower=False):
+        """Get the dimension type, either from axis attr or from match Cf coord
+
+        .. note:: The ``axis`` is the uppercase version of the ``dim_type``
+
+        Parameters
+        ----------
+        coord: xarray.DataArray
+        lower: bool
+            Lower case?
+
+        Return
+        ------
+        {"x", "y", "z", "t", "f"}, None
+
+        See also
+        --------
+        get_dim_type
+        get_dim_types
+        """
         return self.coords.get_axis(coord, lower=lower)
 
     def get_dim_type(self, dim, da=None, lower=True):
+        """Get the type of a dimension
+
+        Three cases:
+
+        - This dimension is registered in CF dims.
+        - obj has dim as dim and has an axis attribute inferred with :meth:`get_axis`.
+        - obj has a coord named dim with an axis attribute inferred with :meth:`get_axis`.
+
+        Parameters
+        ----------
+        dim: str
+            Dimension name
+        obj: xarray.DataArray, xarray.Dataset
+            Data array that the dimension belongs to, to help inferring
+            the type
+        lower: bool
+            For lower case
+
+        Return
+        ------
+        str, None
+            Letter as one of x, y, z, t or f, if found, else None
+
+        See also
+        --------
+        get_axis
+        """
         return self.coords.get_dim_type(dim, da=da, lower=lower)
 
     def get_dim_types(self, da, unknown=None, asdict=False):
-        return self.coords.get_dim_types(
-            da, unknown=unknown, asdict=asdict)
+        """Get a tuple of the dimension types of an array
 
-    def parse_dims(self, dims, dsa):
-        return self.coords.parse_dims(dims, dsa)
+        Parameters
+        ----------
+        obj: xarray.DataArray, tuple(str), xarray.Dataset
+            Data array, dataset or tuple of dimensions
+        unknown:
+            Value to assign when type is unknown
+        asdict: bool
+
+        Return
+        ------
+        tuple, dict
+            Tuple of dimension types and of length ``obj.ndim``.
+            A dimension type is either a letter or the ``unkown`` value
+            when the inference of type has failed.
+            If ``asdict`` is True, a dict is returned instead,
+            ``(dim, dim_type)`` as key-value pairs.
+
+        See also
+        --------
+        get_dim_type
+        """
+        return self.coords.get_dim_types(da, unknown=unknown, asdict=asdict)
+
+    def parse_dims(self, dims, obj):
+        """Convert from generic dim names to specialized names
+
+        Parameters
+        ----------
+        dims: str, tuple, list, dict
+        obj: xarray.Dataset, xarray.DataArray
+
+        Return
+        ------
+        Same type as dims
+        """
+        return self.coords.parse_dims(dims, obj)
 
     def infer_coords(self, ds):
         """Search for known coords and make sure they are set as coords
@@ -1627,6 +2110,7 @@ class CFSpecs(object):
                 if self.coords.match(da):
                     ds = ds.set_coords(da.name)
         return ds.copy()
+
 
 class _CFCatSpecs_(object):
     """Base class for loading data_vars and coords CF specifications"""
@@ -1652,6 +2136,14 @@ class _CFCatSpecs_(object):
     def __init__(self, parent):
         assert self.category in parent
         self.parent = parent
+
+    @property
+    def coords(self):
+        return self.parent.coords
+
+    @property
+    def data_vars(self):
+        return self.parent.data_vars
 
     @property
     def sglocator(self):
@@ -1684,8 +2176,7 @@ class _CFCatSpecs_(object):
     def _assert_known_(self, name, errors="raise"):
         if name not in self._dict:
             if errors == "raise":
-                raise XoaCFError(
-                    f"Invalid {self.category} CF specs name: "+name)
+                raise XoaCFError(f"Invalid {self.category} CF specs name: " + name)
             return False
         return True
 
@@ -1705,7 +2196,7 @@ class _CFCatSpecs_(object):
         Parameters
         ----------
         name: str
-        errors: "silent", "warning" or "error".
+        errors: "ignore", "warning" or "raise".
 
         Return
         ------
@@ -1722,7 +2213,7 @@ class _CFCatSpecs_(object):
 
     @property
     def dims(self):
-        """Dims per dimension types"""
+        """Dict of dim names per type"""
         return self.parent._dict['dims']
 
     def set_specs(self, item, **specs):
@@ -1736,8 +2227,35 @@ class _CFCatSpecs_(object):
             cfg = {self.category: cfg}
         self.parent.load_cfg(cfg)
 
-    def _get_ordered_match_specs_(self, name):
-        specs = self[name]
+    def get_allowed_names(self, cf_name):
+        """Get the list of allowed names for a given `cf_name`
+
+        It includes de `cf_name` itself, the `name` alt_names` specification values
+
+        Parameters
+        ----------
+        cf_name: str
+            Valid CF name
+
+        Return
+        ------
+        list
+        """
+        specs = self[cf_name]
+        allowed_names = [cf_name]
+        if "name" in specs and specs["name"]:
+            allowed_names.append(specs["name"])
+        if "alt_names" in specs:
+            allowed_names.extend(specs["alt_names"])
+        return allowed_names
+
+    def get_loc_mapping(self, obj, cf_names=None):
+        return self.parent.get_loc_mapping(
+            obj, cf_names=cf_names, categories=["coords", "data_vars"]
+        )
+
+    def _get_ordered_match_specs_(self, cf_name):
+        specs = self[cf_name]
         match_specs = {}
         for sm in specs["search_order"]:
             for attr in (
@@ -1751,22 +2269,18 @@ class _CFCatSpecs_(object):
                     continue
                 # if attr == "name" and "name" in specs:
                 if attr == "name":
-                    match_specs["name"] = [name]
-                    if "name" in specs and specs["name"]:
-                        match_specs["name"].append(specs["name"])
-                    if "alt_names" in specs:
-                        match_specs["name"].extend(specs["alt_names"])
+                    match_specs["name"] = self.get_allowed_names(cf_name)
                 elif "attrs" in specs and attr in specs["attrs"]:
                     match_specs[attr] = specs["attrs"][attr]
         return match_specs
 
-    def match(self, da, name=None, loc="any"):
+    def match(self, da, cf_name=None, loc=None):
         """Check if da attributes match given or any specs
 
         Parameters
         ----------
         da: xarray.DataArray
-        name: str, dict, None
+        cf_name: str, dict, None
             CF name.
             If None, all names are used.
             If a dict, name is interpreted as an explicit set of
@@ -1781,10 +2295,10 @@ class _CFCatSpecs_(object):
         bool, str
             True or False if name is provided, else found name or None
         """
-        if name:
-            if isinstance(name, str):
-                self._assert_known_(name)
-            names = [name]
+        if cf_name:
+            if isinstance(cf_name, str):
+                self._assert_known_(cf_name)
+            names = [cf_name]
         else:
             names = self.names
         for name_ in names:
@@ -1803,28 +2317,58 @@ class _CFCatSpecs_(object):
                 for ref in refs:
                     if (
                         attr in self.sglocator.valid_attrs
-                        and self.sglocator.match_attr(
-                            attr, value, ref, loc=loc
-                        )
+                        and self.sglocator.match_attr(attr, value, ref, loc=loc)
                     ) or match_string(value, ref, ignorecase=True):
-                        return True if name else name_
-        return False if name else None
+                        da.encoding["cf_name"] = name_
+                        da.encoding["cf_category"] = self.category
+                        return True if cf_name else name_
+        return False if cf_name else None
+
+    def match_from_name(self, name, cf_name=None, loc=None):
+        """Get the generic CF name of an object knowing only its name
+
+        It compares `name` to the `name` and `alt_names` config values.
+
+        Parameters
+        ----------
+        name: str
+            Actual name
+        cf_name: str, None
+            A target generic CF name. If not provided, all items are considered.
+
+        Return
+        ------
+        None, str, True, False
+            If `cf_name` is provided, returns a boolean, else returns
+            the matching CF name or None.
+        """
+        explicit = cf_name is not None
+        if cf_name:
+            self._assert_known_(cf_name)
+            cf_names = [cf_name]
+        else:
+            cf_names = self.names
+
+        for cf_name in cf_names:
+            for allowed_name in self.get_allowed_names(cf_name):
+                if self.sglocator.match_attr("name", name, allowed_name, loc=loc):
+                    return cf_name if not explicit else True
+        return None if not explicit else False
 
     @ERRORS.format_method_docstring
-    def search(self, dsa, name=None, loc="any", get="obj", single=True,
-               errors="raise"):
+    def search(self, obj, cf_name=None, loc=None, get="obj", single=True, errors="raise"):
         """Search for a data_var or coord that maches given or any specs
 
         Parameters
         ----------
-        dsa: DataArray or Dataset
-        name: str, dict
-            A CF name. If not provided, all CF names are scaned.
+        obj: DataArray or Dataset
+        cf_name: str, dict
+            A generic CF name. If not provided, all CF names are scaned.
         loc: str, {{"any", None}}, {{"", False}}
             - str: one of these locations
             - None or "any": any
             - False or '"": no location
-        get: {{"obj", "name"}}
+        get: {{"obj", "cf_name", "both"}}
             When found, get the object found or its name.
         single: bool
             If True, return the first item found or None.
@@ -1838,25 +2382,28 @@ class _CFCatSpecs_(object):
         """
 
         # Get target objects
-        if self.category and hasattr(dsa, self.category):
-            objs = getattr(dsa, self.category)
+        if self.category and hasattr(obj, self.category):
+            objs = getattr(obj, self.category)
         else:
-            objs = dsa.keys() if hasattr(dsa, "keys") else dsa.coords
+            objs = obj.keys() if hasattr(obj, "keys") else obj.coords
 
         # Get match specs
-        if name:  # Explicit name so we loop on search specs
-            if isinstance(name, str):
-                if not self._assert_known_(name, errors):
+        if cf_name:  # Explicit name so we loop on search specs
+            if isinstance(cf_name, str):
+                if not self._assert_known_(cf_name, errors):
                     return
             match_specs = []
-            for attr, refs in self._get_ordered_match_specs_(name).items():
+            for attr, refs in self._get_ordered_match_specs_(cf_name).items():
                 match_specs.append({attr: refs})
         else:
             match_specs = [None]
 
         # Loops
-        assert get in ("name", "obj", "both"), (
-            "'get' must be either 'name' or 'obj' or 'both'")
+        assert get in (
+            "cf_name",
+            "obj",
+            "both",
+        ), f"'get' must be either 'cf_name' or 'obj' or 'both', NOT '{get}'"
         found = []
         found_objs = []
         for match_arg in match_specs:
@@ -1866,11 +2413,11 @@ class _CFCatSpecs_(object):
                     if obj.name in found_objs:
                         continue
                     found_objs.append(obj.name)
-                    name = name if name else m
+                    cf_name = cf_name if cf_name else m
                     if get == "both":
-                        found.append((obj, name))
+                        found.append((obj, cf_name))
                     else:
-                        found.append(obj if get == "obj" else name)
+                        found.append(obj if get == "obj" else cf_name)
 
         # Return
         if not single:
@@ -1889,21 +2436,28 @@ class _CFCatSpecs_(object):
                 raise XoaCFError(msg)
             xoa_warn(msg)
 
-    def get(self, dsa, name):
+    def get(self, obj, cf_name):
         """Call to :meth:`search` with an explicit name and ignoring errors"""
-        return self.search(dsa, name, errors="ignore")
+        return self.search(obj, cf_name, errors="ignore")
 
     @ERRORS.format_method_docstring
     def get_attrs(
-        self, name, select=None, exclude=None, errors="warn", loc=None,
-        multi=False, standardize=True, **extra
+        self,
+        cf_name,
+        select=None,
+        exclude=None,
+        errors="warn",
+        loc=None,
+        multi=False,
+        standardize=True,
+        **extra,
     ):
         """Get the default attributes from cf specs
 
         Parameters
         ----------
-        name: str
-            Valid CF name
+        cf_name: str
+            Valid generic CF name
         select: str, list
             Include only these attributes
         exclude: str, list
@@ -1921,7 +2475,7 @@ class _CFCatSpecs_(object):
         """
 
         # Get specs
-        specs = self.get_specs(name, errors=errors)
+        specs = self.get_specs(cf_name, errors=errors)
         if not specs:
             return {}
 
@@ -1957,8 +2511,7 @@ class _CFCatSpecs_(object):
         attrs.update(extra)
 
         # Finalize and optionally change location
-        attrs = self.parent.sglocator.format_attrs(
-            attrs, loc=loc, standardize=standardize)
+        attrs = self.parent.sglocator.format_attrs(attrs, loc=loc, standardize=standardize)
 
         return attrs
 
@@ -1968,7 +2521,7 @@ class _CFCatSpecs_(object):
         Parameters
         ----------
         name: str, xarray.DataArray
-            Either a cf name or a data array
+            Either a data array, a known cf name or a data var name
         specialize: bool
             Get the first name
             as listed in specs, which is generally a specialized one,
@@ -1979,25 +2532,73 @@ class _CFCatSpecs_(object):
         Return
         ------
         None or str
+            Either the CF name or the specialized name
         """
         if not isinstance(name, str):
-            name = self.match(name)
+            name = name.encoding.get("cf_name", self.match(name))
+            # FIXME: category?
+        elif name not in self:
+            name = self.match_from_name(name)
         if name is None:
             return
         if specialize and self[name]["name"]:
             name = self[name]["name"]
         return self.sglocator.format_attr("name", name, loc=loc)
 
+    def get_loc_arg(self, da, cf_name=None, locations=None):
+        """Get the `loc` argument from a name or data array with name
+
+        Parameters
+        ----------
+        da: xarray.DataArray
+        cf_name: None, str
+            A generic CF name
+        locations: None, dict
+
+        Return
+        ------
+        None, False, str
+        """
+        # Just a name
+        # FIXME: really?
+        if isinstance(da, str):
+            return self.sglocator.parse_attr("name", da)[1]
+
+        # From config
+        # if "cf_loc" in da.encoding:  # Already infered and stored in encoding
+        #     loc = da.encoding["cf_loc"]
+        # else:  # Infer from config
+        if locations is None:
+            locations = self.get_loc_mapping(da, cf_names={da.name: cf_name})
+        loc = locations.get(da.name)
+        if loc is not None:
+            return loc
+
+        # From the array attributes
+        return self.sglocator.get_loc_from_da(da)
+
     def format_dataarray(
-            self, da, name=None, loc=None, rename=True, attrs=True, standardize=True,
-            specialize=False, rename_dim=True, replace_attrs=False, copy=True, add_loc_to_name=None):
+        self,
+        da,
+        cf_name=None,
+        rename=True,
+        specialize=False,
+        # rename_dim=True,
+        loc=None,
+        attrs=True,
+        standardize=True,
+        replace_attrs=False,
+        copy=True,
+        # add_loc_to_name=None,
+        bound_to=None,
+    ):
         """Format a DataArray's name and attributes
 
         Parameters
         ----------
         da: xarray.DataArray
-        name: str, None
-            A CF name. If not provided, it guessed with :meth:`match`.
+        cf_name: str, None
+            A generic CF name. If not provided, it guessed with :meth:`match`.
         loc: str, {"any", None}, {"", False}
             - str: one of these locations
             - None or "any": any
@@ -2014,9 +2615,8 @@ class _CFCatSpecs_(object):
             Replace existing attributes?
         standardize: bool
         specialize: bool
-            Does not use the CF name for renaming, but the first name
-            as listed in specs, which is generally a specialized one,
-            like a name adopted by specialized dataset.
+            Do not use the CF name for renaming, but the value of the "name" entry,
+            which is generally a specialized one, like a name adopted by specialized dataset.
         rename_dim: bool
             For a 1D array, rename the dimension if it has the same name
             as the array.
@@ -2037,27 +2637,31 @@ class _CFCatSpecs_(object):
         if copy:
             da = da.copy()
 
-        # Get names
-        if name is None:
-            name = self.match(da, loc="any")
-        if name is None:
+        # Names
+        if cf_name is None:
+            cf_name = self.match(da)
+        if cf_name is None:
             if not rename:
                 return
             return da.copy() if copy else None
-        assert name in self.names
+        assert cf_name in self.names
         old_name = da.name
-        cf_name = name
-        new_name = self.get_name(cf_name, specialize=specialize)
-        if add_loc_to_name is None:
-            add_loc_to_name = self[cf_name]["add_loc"]
-        if add_loc_to_name is None and old_name:
-            add_loc_to_name = bool(self.sglocator.parse_attr("name", old_name)[1])
+        new_name = self.get_name(cf_name, specialize=specialize)  # if specialize else cf_name
+
+        # Location
+        if loc is None:
+            loc = self.get_loc_arg(da)  # from config
 
         # Attributes
         if attrs is True:
+
+            # Get attributes from Cf specs
             attrs = self.get_attrs(cf_name, loc=None, standardize=False, multi=True)
+
+            # Remove axis attribute for auxilary coordinates
             if da.name and da.name not in da.indexes and "axis" in attrs:
                 del attrs["axis"]
+
         elif not attrs:
             attrs = {}
 
@@ -2069,28 +2673,36 @@ class _CFCatSpecs_(object):
             attrs=attrs,
             standardize=standardize,
             rename=rename,
-            add_loc_to_name=add_loc_to_name,
+            # add_loc_to_name=add_loc_to_name,
             replace_attrs=replace_attrs,
-            copy=False
+            copy=False,
         )
+        # new_da.encoding["cf_name"] = cf_name
 
-        # Return renaming name but don't rename
+        # Return new name but don't rename
         if not rename:
-            if not add_loc_to_name:
-                return new_name
-            if loc is None or loc == "any":
-                loc = self.sglocator.get_location(new_da)
+            if old_name is None:
+                return self.sglocator.format_attr("name", new_name, loc)
             return self.sglocator.merge_attr("name", old_name, new_name, loc)
 
-        # Rename dim if axis coordinate
-        rename_dim = rename and rename_dim
-        if (rename_dim and old_name and old_name in da.indexes):
-            new_da = new_da.rename({old_name: new_da.name})
+        # # Rename dim if axis coordinate
+        # rename_dim = rename and rename_dim
+        # if (rename_dim and old_name and old_name in da.indexes):
+        #     new_da = new_da.rename({old_name: new_da.name})
+
         return new_da
 
     def rename_dataarray(
-            self, da, name=None, specialize=False, loc=None, standardize=True, rename_dim=True,
-            copy=True, add_loc_to_name=None):
+        self,
+        da,
+        name=None,
+        specialize=False,
+        loc=None,
+        standardize=True,
+        rename_dim=True,
+        copy=True,
+        add_loc_to_name=None,
+    ):
         """Rename a DataArray
 
         It is a specialized call to :meth:`format_dataarray` where
@@ -2123,9 +2735,16 @@ class _CFCatSpecs_(object):
         format_dataarray
         """
         return self.format_dataarray(
-            da, name=name, specialize=specialize, loc=loc, attrs=False,
-            standardize=standardize, rename_dim=rename_dim, copy=copy,
-            add_loc_to_name=add_loc_to_name)
+            da,
+            name=name,
+            specialize=specialize,
+            loc=loc,
+            attrs=False,
+            standardize=standardize,
+            rename_dim=rename_dim,
+            copy=copy,
+            add_loc_to_name=add_loc_to_name,
+        )
 
 
 class CFVarSpecs(_CFCatSpecs_):
@@ -2138,6 +2757,9 @@ class CFCoordSpecs(_CFCatSpecs_):
     """CF specification for coords"""
 
     category = "coords"
+
+    def get_loc_mapping(self, da, cf_names=None):
+        return self.parent.get_loc_mapping(da, cf_names=cf_names, categories=["coords"])
 
     def get_axis(self, coord, lower=False):
         """Get the dimension type, either from axis attr or from match Cf coord
@@ -2171,20 +2793,20 @@ class CFCoordSpecs(_CFCatSpecs_):
                 return axis.lower()
             return axis.upper()
 
-    def get_dim_type(self, dim, da=None, lower=True):
+    def get_dim_type(self, dim, obj=None, lower=True):
         """Get the type of a dimension
 
         Three cases:
 
         - This dimension is registered in CF dims.
-        - da has dim as dim and has an axis attribute inferred with :meth:`get_axis`.
-        - da has a coord named dim with an axis attribute inferred with :meth:`get_axis`.
+        - obj has dim as dim and has an axis attribute inferred with :meth:`get_axis`.
+        - obj has a coord named dim with an axis attribute inferred with :meth:`get_axis`.
 
         Parameters
         ----------
         dim: str
             Dimension name
-        da: xarray.DataArray
+        obj: xarray.DataArray, xarray.Dataset
             Data array that the dimension belongs to, to help inferring
             the type
         lower: bool
@@ -2211,28 +2833,29 @@ class CFCoordSpecs(_CFCatSpecs_):
                 return dim_type
 
         # Check if a coordinate have the same name and an axis type
-        if da is not None:
+        if obj is not None:
 
             # Check dim validity
-            if dim_loc not in da.dims:
-                raise XoaCFError(f"dimension '{dim}' does not belong to da")
+            if dim_loc not in obj.dims:
+                raise XoaCFError(f"dimension '{dim}' does not belong to obj")
 
             # Check axis from coords
-            if dim in da.indexes:
-                return self.get_axis(da.coords[dim], lower=True)
+            if dim in obj.indexes:
+                return self.get_axis(obj.coords[dim], lower=True)
 
-            # Check da axis itself
-            axis = self.get_axis(da, lower=True)
-            if axis:
-                return axis
+            # Check obj axis itself
+            if not hasattr(obj, "data_vars"):
+                axis = self.get_axis(obj, lower=True)
+                if axis:
+                    return axis
 
-    def get_dim_types(self, da, unknown=None, asdict=False):
+    def get_dim_types(self, obj, unknown=None, asdict=False):
         """Get a tuple of the dimension types of an array
 
         Parameters
         ----------
-        da: xarray.DataArray or tuple(str)
-            Data array or tuple of dimensions
+        obj: xarray.DataArray, tuple(str), xarray.Dataset
+            Data array, dataset or tuple of dimensions
         unknown:
             Value to assign when type is unknown
         asdict: bool
@@ -2240,7 +2863,7 @@ class CFCoordSpecs(_CFCatSpecs_):
         Return
         ------
         tuple, dict
-            Tuple of dimension types and of length ``da.ndim``.
+            Tuple of dimension types and of length ``obj.ndim``.
             A dimension type is either a letter or the ``unkown`` value
             when the inference of type has failed.
             If ``asdict`` is True, a dict is returned instead,
@@ -2251,13 +2874,13 @@ class CFCoordSpecs(_CFCatSpecs_):
         get_dim_type
         """
         dim_types = {}
-        if isinstance(da, tuple):
-            dims = da
-            da = None
+        if isinstance(obj, tuple):
+            dims = obj
+            obj = None
         else:
-            dims = da.dims
+            dims = obj.dims
         for dim in dims:
-            dim_type = self.get_dim_type(dim, da=da)
+            dim_type = self.get_dim_type(dim, obj=obj)
             if dim_type is None:
                 dim_type = unknown
             dim_types[dim] = dim_type
@@ -2266,8 +2889,8 @@ class CFCoordSpecs(_CFCatSpecs_):
         return tuple(dim_types.values())
 
     @ERRORS.format_method_docstring
-    def search_dim(self, da, dim_type=None, loc="any", errors="ignore"):
-        """Search a dataarray for a dimension name according to its type
+    def search_dim(self, obj, cf_arg=None, loc=None, errors="ignore"):
+        """Search a dataarray/dataset for a dimension name according to its generic name or type
 
         First, scan the dimension names.
         Then, look for coordinates: either it has an 'axis' attribute,
@@ -2275,67 +2898,85 @@ class CFCoordSpecs(_CFCatSpecs_):
 
         Parameters
         ----------
-        da: xarray.DataArray
+        obj: xarray.DataArray, xarray.Dataset
             Coordinate or data array
-        dim_type: {{"x", "y", "z", "t", "f"}}, None
-            When set to None, it is inferred with :meth:`get_axis`
+        cf_arg: str, {{"x", "y", "z", "t", "f"}}, None
+            One-letter imension type or generic name.
+            When set to None, dmension type is inferred with :meth:`get_axis`
+            applied to `obj`
         loc: "any", letter
             Staggered grid location
         {errors}
 
         Return
         ------
-        str, (str, str), None
-            Dim name OR, (dim name, dim_type) if dim_type is None.
+        str, dict, None
+            Dim name OR, dict with dim, type and cf_name keys if dim_type is None.
             None if nothing found.
         """
-        # Fixed dim type?
-        with_dim_type = dim_type is not None
-        if with_dim_type:
-            dim_type = dim_type.lower()
-        else:
-            dim_type = self.get_axis(da, lower=True)
+        # Explicit?
+        cf_name = dim_type = None
+        if cf_arg:
+            if cf_arg in obj.dims:
+                return cf_arg
+            if len(cf_arg) == 1:
+                dim_type = cf_arg.lower()
+                if cf_arg in self.names:
+                    cf_name = cf_arg
+            else:
+                self._assert_known_(cf_arg)
+                cf_name = cf_arg
+        isds = hasattr(obj, "data_vars")
+        if not isds and dim_type is None:
+            dim_type = self.get_axis(obj, lower=True)
+        loc = self.sglocator.parse_loc_arg(loc)
 
         # Loop on dims
-        for dim in da.dims:
+        for dim in obj.dims:
 
-            # Filter by loc
+            # Filter-out by loc
             pname, ploc = self.sglocator.parse_attr('name', dim)
-            if loc != "any" and ploc and loc and loc != ploc:
+            ploc = self.sglocator.parse_loc_arg(ploc)
+            if loc is not None and ploc and loc and loc != ploc:
                 continue
 
-            # Type of the current dim
-            this_dim_type = self.get_dim_type(dim, da=da)
-
-            # This must match dim_type
-            if with_dim_type:
-                if this_dim_type and this_dim_type == dim_type:
+            # From generic name
+            if dim in obj.coords:
+                this_cf_name = self.match(obj.coords[dim])
+            else:
+                this_cf_name = self.match_from_name(dim)
+            if cf_name:
+                if this_cf_name == cf_name:
                     return dim
                 continue
 
-            # Any dim_type but no ambiguity because same as da
-            elif dim_type and this_dim_type and this_dim_type == dim_type:
-                return dim, dim_type
+            # From dimension type
+            this_dim_type = self.get_dim_type(dim, obj=obj)
+            out = {"dim": dim, "type": this_dim_type, "cf_name": this_cf_name}
+            if this_dim_type and this_dim_type == dim_type:
+                if cf_arg:
+                    return dim
+                return out
 
         # Not found but only 1d and no dim_type specified
-        if da.ndim == 1 and not with_dim_type:
-            #FIXME: loop on coordinates?
-            return dim, this_dim_type
+        if len(obj.dims) == 1 and not cf_arg:
+            # FIXME: loop on coordinates?
+            return out
 
         # Failed
         errors = ERRORS[errors]
         if errors != "ignore":
-            msg = f"No dimension found in dataarray matching type: {dim_type}"
+            msg = f"No dimension found in dataarray matching: {cf_arg}"
             if errors == "raise":
                 raise XoaCFError(msg)
             xoa_warn(msg)
-        if with_dim_type:
-            return
-        return None, None
+        # if cf_arg is None:
+        #     return
+        # return None, None
 
     @ERRORS.format_method_docstring
-    def search_from_dim(self, da, dim, errors="ignore"):
-        """Search a dataarray for a coordinate from a dimension name
+    def search_from_dim(self, obj, dim, errors="ignore"):
+        """Search a dataarray/dataset for a coordinate from a dimension name
 
         It first searches for a coordinate with a different name and that is
         the only one having this dimension.
@@ -2344,7 +2985,7 @@ class CFCoordSpecs(_CFCatSpecs_):
 
         Parameters
         ----------
-        da: xarray.DataArray
+        obj: xarray.DataArray, xarray.Dataset
         dim: str
         {errors}
 
@@ -2358,28 +2999,30 @@ class CFCoordSpecs(_CFCatSpecs_):
         get_axis
         get_dim_type
         """
-        if dim not in da.dims:
+        if dim not in obj.dims:
             raise XoaError(f"Invalid dimension: {dim}")
 
         # A coord with a different name
-        coords = [coord for name, coord in da.coords.items() if name != dim and dim in coord.dims]
+        coords = [coord for name, coord in obj.coords.items() if name != dim and dim in coord.dims]
         if len(coords) == 1:
             return coords[0]
 
         # As an index
-        if dim in da.indexes:
-            return da.coords[dim]
+        if dim in obj.indexes:
+            return obj.coords[dim]
 
         # Get dim_type from known dim name
-        dim_type = self.get_dim_type(dim, da=da, lower=True)
+        dim_type = self.get_dim_type(dim, obj, lower=True)
 
         # So we can do something
+        def get_ndim(o):
+            return len(o.dims)
         if dim_type is not None:
 
             # Look for a coordinate with this dim_type
             #  starting from coordinates with a higher number of dimensions
             #  like depth that have more dims than level
-            for coord in sorted(da.coords.values(), key=operator.attrgetter('ndim'), reverse=True):
+            for coord in sorted(obj.coords.values(), key=get_ndim, reverse=True):
                 if dim in coord.dims:
                     coord_dim_type = self.get_axis(coord, lower=True)
                     if coord_dim_type and coord_dim_type == dim_type:
@@ -2394,20 +3037,20 @@ class CFCoordSpecs(_CFCatSpecs_):
             xoa_warn(msg)
 
     @ERRORS.format_method_docstring
-    def get_dims(self, da, dim_types, allow_positional=False,
-                 positions='tzyx', errors="warn"):
+    def get_dims(self, obj, cf_args, allow_positional=False, positions='tzyx', errors="warn"):
         """Get the data array dimensions names from their type
 
         Parameters
         ----------
-        da: xarray.DataArray
-            Array to scan
-        dim_types: str, list
-            Letters among "x", "y", "z", "t" and "f".
+        obj: xarray.DataArray, xarray.Dataset
+            Array/dataset to scan
+        cf_args: list
+            List of letters among "x", "y", "z", "t" and "f",
+            or generic names.
         allow_positional: bool
             Fall back to positional dimension of types is unkown.
         positions: str
-            Default expected position of dim per type in da
+            Default expected position of dim per type in `obj`
             starting from the end.
         {errors}
 
@@ -2423,9 +3066,12 @@ class CFCoordSpecs(_CFCatSpecs_):
         """
         # Check shape
         errors = ERRORS[errors]
-        if len(dim_types) > da.ndim:
-            msg = (f"this data array has less dimensions ({da.ndim})"
-                   " than requested ({})".format(len(dim_types)))
+        dims = list(obj.dims)
+        ndim = len(dims)
+        if len(cf_args) > len(dims):
+            msg = f"this data array has less dimensions ({ndim})" " than requested ({})".format(
+                len(cf_args)
+            )
             if errors == "raise":
                 raise XoaError(msg)
             if errors == "warn":
@@ -2433,65 +3079,98 @@ class CFCoordSpecs(_CFCatSpecs_):
 
         # Loop on types
         scanned = {}
-        for dim_type in dim_types:
-            scanned[dim_type] = self.search_dim(da, dim_type)
+        for cf_arg in cf_args:
+            scanned[cf_arg] = self.search_dim(obj, cf_arg)
 
         # Guess from position
         if allow_positional:
-            not_found = [item[0] for item in scanned.items()
-                         if item[1] is None]
-            for i, dim_type in enumerate(positions[::-1]):
-                if dim_type in not_found:
-                    scanned[dim_type] = da.dims[-i-1]
+            not_found = [item[0] for item in scanned.items() if item[1] is None]
+            for i, cf_arg in enumerate(positions[::-1]):
+                if cf_arg in not_found:
+                    scanned[cf_arg] = dims[-i - 1]
 
         # Final check
         if errors != 'ignore':
-            for dim_type, dim in scanned.items():
+            for cf_arg, dim in scanned.items():
                 if dim is None:
-                    msg = f"no dimension found of type '{dim_type}'"
+                    msg = f"no dimension found matching: {cf_arg}"
                     if errors == 'raise':
                         raise XoaError(msg)
                     xoa_warn(msg)
 
         return tuple(scanned.values())
 
-    def get_rename_dims_args(self, dsa, loc=None, specialize=False):
-        """Get args for renaming dimensions that are not coordinates"""
+    def get_rename_dims_args(self, obj, locations=None, specialize=False):
+        """Get args for renaming dimensions that are not coordinates
+
+        Parameters
+        ----------
+        obj: xarray.DataArray, xarray.Dataset
+            Array or dataset
+        locations: dict, None
+            Dict of staggerd grid location with dim names as keys
+        specialize: bool
+            Does not use the CF name for renaming, but the first name
+            as listed in specs, which is generally a specialized one,
+            like a name adopted by specialized dataset.
+
+        Return
+        ------
+        dict:
+            Argument compatible with :meth:`xarray.Dataset.rename`
+        """
+
+        # Get location specs
+        if locations is None:
+            locations = self.get_loc_mapping(obj)
+
+        # Loop on dims
         rename_args = {}
-        for dim in dsa.dims:
-            if dim in dsa.coords:
+        for dim in obj.dims:
+
+            # Skip effective coordinate dims
+            if dim in obj.coords:
                 continue
-            dim_type = self.get_dim_type(dim, dsa)
-            if dim_type:
-                if specialize and self.dims[dim_type]:
-                    new_name = self.dims[dim_type][0]
-                else:
-                    new_name = dim_type
-                new_name = self.sglocator.merge_attr('name', dim, new_name, loc=loc)
+
+            # Is it known?
+            cf_dim_name = self.match_from_name(dim)  # known coordinate name
+            dim_type = self.get_dim_type(dim, obj)  # known dimension type
+            dim_loc = locations.get(dim)
+
+            # Root name
+            if cf_dim_name:
+                new_name = self.get_name(cf_dim_name, specialize=specialize)
+            elif dim_type:
+                new_name = dim_type
+            else:
+                new_name = dim
+
+            # Add loc
+            if dim_loc is not False:
+                new_name = self.sglocator.merge_attr('name', dim, new_name, loc=dim_loc)
+
+            # Register arg
+            if new_name != dim:
                 rename_args[dim] = new_name
+
         return rename_args
 
-
-    def parse_dims(self, dims, dsa):
+    def parse_dims(self, dims, obj):
         """Convert from generic dim names to specialized names
 
         Parameters
         ----------
         dims: str, tuple, list, dict
-        dsa: xarray.Dataset, xarray.DataArray
+        obj: xarray.Dataset, xarray.DataArray
 
         Return
         ------
         Same type as dims
         """
-        dim_types = self.get_dim_types(dsa, asdict=True)
-        def _parse_dim_(dim):
-            if dim not in dsa.dims:
-                for dsadim, dim_type in dim_types.items():
-                    if dim == dim_type:
-                        dim = dsadim
-                        break
-            return dim
+        # dim_types = self.get_dim_types(obj, asdict=True)
+
+        def _parse_dim_(cf_arg):
+            return self.search_dim(obj, cf_arg) or cf_arg
 
         if isinstance(dims, str):
             return _parse_dim_(dims)
@@ -2500,8 +3179,7 @@ class CFCoordSpecs(_CFCatSpecs_):
         return type(dims)(_parse_dim_(dim) for dim in dims)
 
 
-for meth in ('get_axis', 'get_dim_type', 'get_dim_types',
-             'search_dim', 'get_dims'):
+for meth in ('get_axis', 'get_dim_type', 'get_dim_types', 'search_dim', 'get_dims'):
     doc = getattr(CFCoordSpecs, meth).__doc__
     getattr(CFSpecs, meth).__doc__ = doc
 
@@ -2533,14 +3211,17 @@ def get_matching_item_specs(da, loc="any"):
     CFSpecs.match
     """
     cfspecs = get_cf_specs(da)
-    cat, name =  cfspecs.match(da, loc=loc)
+    cat, name = cfspecs.match(da, loc=loc)
     if cat:
         return cfspecs[cat][name]
 
 
 def _same_attr_(da0, da1, attr):
-    return (attr in da0.attrs and attr in da1.attrs and
-            da0.attrs[attr].lower() == da1.attrs[attr].lower())
+    return (
+        attr in da0.attrs
+        and attr in da1.attrs
+        and da0.attrs[attr].lower() == da1.attrs[attr].lower()
+    )
 
 
 def are_similar(da0, da1):
@@ -2569,7 +3250,7 @@ def are_similar(da0, da1):
     # Cf name
     cf0 = get_matching_item_specs(da0)
     cf1 = get_matching_item_specs(da1)
-    if (cf0 and cf1 and cf0.name == cf1.name):
+    if cf0 and cf1 and cf0.name == cf1.name:
         return True
 
     # Name
@@ -2580,14 +3261,14 @@ def are_similar(da0, da1):
     return _same_attr_(da0, da1, "long_name")
 
 
-def search_similar(dsa, da):
+def search_similar(obj, da):
     """Search in ds for a similar DataArray
 
     See :func:`is_similar` for what means "similar".
 
     Parameters
     ----------
-    dsa: xarray.Dataset, xarray.DataArray
+    obj: xarray.Dataset, xarray.DataArray
         Dataset that must be scanned.
     da: xarray.DataArray
         Array that must be compared to the content of ``ds``
@@ -2602,7 +3283,7 @@ def search_similar(dsa, da):
     get_matching_item_specs
     """
     targets = list(da.coords.values())
-    if hasattr(dsa, "data_vars"):
+    if hasattr(obj, "data_vars"):
         targets = list(da.data_vars.values()) + targets
     for ds_da in targets:
         if are_similar(ds_da, da):
@@ -2702,7 +3383,7 @@ def get_cf_specs_from_name(name, errors="warn"):
 
 
 def get_cf_specs_encoding(ds):
-    """Get the ``cfspecs`` encoding value
+    """Get the ``cf_specs`` encoding value
 
     Parameters
     ----------
@@ -2719,12 +3400,12 @@ def get_cf_specs_encoding(ds):
     if ds is not None and not isinstance(ds, str):
         for source in ds.encoding, ds.attrs:
             for attr, value in source.items():
-                if attr.lower() == "cfspecs":
+                if attr.lower() == "cf_specs":
                     return value
 
 
 def get_cf_specs_from_encoding(ds):
-    """Get a registered CF specs instance from the ``cfspecs`` encoding value
+    """Get a registered CF specs instance from the ``cf_specs`` encoding value
 
     Parameters
     ----------
@@ -2772,16 +3453,13 @@ def get_default_cf_specs(cache="rw"):
     # Try from disk cache
     if cache in ("read", "rw"):
         if os.path.exists(USER_CF_CACHE_FILE) and (
-            os.stat(_CFGFILE).st_mtime <
-            os.stat(USER_CF_CACHE_FILE).st_mtime
+            os.stat(_CFGFILE).st_mtime < os.stat(USER_CF_CACHE_FILE).st_mtime
         ):
             try:
                 with open(USER_CF_CACHE_FILE, "rb") as f:
                     cfspecs = pickle.load(f)
             except Exception as e:
-                xoa_warn(
-                    "Error while loading cached cf specs: " + str(e.args)
-                )
+                xoa_warn("Error while loading cached cf specs: " + str(e.args))
 
     # Compute it from scratch
     if cfspecs is None:
@@ -2817,7 +3495,7 @@ def get_cf_specs(name=None, cache="rw"):
         which defaults to the xoa defaults!
         Else registration name for these specs or a data array or dataset
         that can be used to get the registration name if it set in the
-        :attr:`cfspecs` attribute or encoding.
+        :attr:`cf_specs` attribute or encoding.
         When set, ``cache`` is ignored.
         Raises a :class:`XoaCFError` is case of invalid name.
     cache: str, bool, None
@@ -2844,7 +3522,7 @@ def get_cf_specs(name=None, cache="rw"):
 
         # Registered name
         if isinstance(name, str):
-           return get_cf_specs_from_name(name, errors="raise")
+            return get_cf_specs_from_name(name, errors="raise")
 
         # Name as dataset or data array so we guess the name
         cfspecs = get_cf_specs_from_encoding(name)
@@ -2858,7 +3536,7 @@ def get_cf_specs(name=None, cache="rw"):
         cf_cache = _get_cache_()
         if cf_cache["current"] is None:
             cf_cache["current"] = get_default_cf_specs()
-        cfspecs =  cf_cache["current"]
+        cfspecs = cf_cache["current"]
     else:
         cfspecs = get_default_cf_specs()
 
@@ -2924,8 +3602,11 @@ def is_registered_cf_specs(name):
     bool
     """
     for cfspecs in get_registered_cf_specs():
-        if (isinstance(name, str) and cfspecs["register"]["name"] and
-                cfspecs["register"]["name"] == name):
+        if (
+            isinstance(name, str)
+            and cfspecs["register"]["name"]
+            and cfspecs["register"]["name"] == name
+        ):
             return True
         if isinstance(name, CFSpecs) and name is cfspecs:
             return True
@@ -2949,8 +3630,7 @@ def get_cf_specs_matching_score(ds, cfspecs):
     hit = 0
     total = 0
     for cat in "data_vars", "coords":
-        cfnames = [cfspecs[cat].get_name(name, specialize=True)
-                   for name in cfspecs[cat].names]
+        cfnames = [cfspecs[cat].get_name(name, specialize=True) for name in cfspecs[cat].names]
         if not hasattr(ds, "data_vars"):  # DataArray
             dsnames = [ds.name] if ds.name else []
         else:
@@ -2967,7 +3647,7 @@ def infer_cf_specs(ds, named=False):
     """Get the registered CFSpecs that are best matching this dataset
 
     This accomplished with some heurestics.
-    First, the :attr:`cfspecs` global attribute or encoding of the dataset is compared
+    First, the :attr:`cf_specs` global attribute or encoding of the dataset is compared
     with the name of all registered datasets.
     Second, a score based on the number of data_vars and coord names
     that are both in the cfspecs and the dataset is computed by :func:`get_cf_specs_matching_score`
@@ -3031,7 +3711,7 @@ def infer_cf_specs(ds, named=False):
 
 
 def assign_cf_specs(ds, name=None, register=False):
-    """Set the ``cfspecs`` encoding to ``name`` in all data vars and coords
+    """Set the ``cf_specs`` encoding to ``name`` in all data vars and coords
 
     Parameters
     ----------
@@ -3093,11 +3773,24 @@ def assign_cf_specs(ds, name=None, register=False):
     if hasattr(ds, "data_vars"):
         targets.extend(list(ds.data_vars.values()))
     for target in targets:
-        target.encoding.update(cfspecs=name)
+        target.encoding.update(cf_specs=name)
     return ds
 
 
 def infer_coords(ds):
+    """Infer which of the data arrays of a dataset are coordinates
+
+    When coordinates are found, it makes sure they are registered in the dataset
+    as coordindates.
+
+    Parameters
+    ----------
+    ds: xarray.Dataset
+
+    See also
+    --------
+    CFSpecs.infer_coords
+    """
     return get_cf_specs(ds).infer_coords(ds)
 
 

--- a/xoa/cfgm.py
+++ b/xoa/cfgm.py
@@ -459,6 +459,23 @@ def is_daterange64(value, default=None):
     return np.arange(value[0], value[1], dtype="M8[{}]".format(value[2]))
 
 
+def is_boolstr(value, default=None):
+    """Validation function of a boolean or a string"""
+    if str(value) == "None":
+        return
+    if isinstance(value, str):
+        try:
+            return validate.bool_dict[value.lower()]
+        except KeyError:
+            return value
+    if value == False:
+        return False
+    elif value == True:
+        return True
+    else:
+        raise VdtTypeError(value)
+
+
 def is_eval(value, default=None, unchanged_if_failed=True):
     """Validate a string that can be evaluated"""
     try:
@@ -585,6 +602,7 @@ VALIDATOR_SPECS = {
     "cmap": is_cmap,
     "color": is_color,
     "dict": is_dict,
+    "boolstr": is_boolstr
     # lists validators for these scalars will be automatically generated
 }
 
@@ -1614,7 +1632,7 @@ def opt2rst(shelp, prog=None, secfmt=":{secname}:", descname="Description"):
 def _opt2cfgname_(name, nested):
     cfgkey = name.replace("-", "_")
     if nested and cfgkey.startswith(nested + "_"):
-        cfgkey = cfgkey[len(nested + "_") :]
+        cfgkey = cfgkey[len(nested + "_"):]
     return cfgkey
 
 

--- a/xoa/coords.py
+++ b/xoa/coords.py
@@ -408,15 +408,16 @@ def get_cf_coords(da, coord_names, errors="raise"):
 
 
 @misc.ERRORS.format_function_docstring
-def get_dims(da, dim_types, allow_positional=False, positions='tzyx', errors="warn"):
+def get_cf_dims(da, cf_args, allow_positional=False, positions='tzyx', errors="warn"):
     """Get the data array dimensions names from their type
 
     Parameters
     ----------
     da: xarray.DataArray
         Array to scan
-    dim_types: str, list
-        Letters among "x", "y", "z", "t" and "f".
+    cf_args: str, list
+        Letters among "x", "y", "z", "t" and "f",
+        or generic CF names.
     allow_positional: bool
         Fall back to positional dimension of types if unkown.
     positions: str
@@ -433,7 +434,7 @@ def get_dims(da, dim_types, allow_positional=False, positions='tzyx', errors="wa
     xoa.cf.CFSpecs.get_dims
     """
     return xcf.get_cf_specs(da).get_dims(
-        da, dim_types, allow_positional=allow_positional,
+        da, cf_args, allow_positional=allow_positional,
         positions=positions, errors=errors)
 
 
@@ -462,7 +463,7 @@ def get_xdim(da, errors="warn", **kwargs):
     --------
     get_dims
     """
-    dims = get_dims(da, "x", errors=errors)
+    dims = get_cf_dims(da, "x", errors=errors)
     if dims:
         return dims[0]
 
@@ -492,7 +493,7 @@ def get_ydim(da, errors="warn", **kwargs):
     --------
     get_dims
     """
-    dims = get_dims(da, "y", errors=errors)
+    dims = get_cf_dims(da, "y", errors=errors)
     if dims:
         return dims[0]
 
@@ -522,7 +523,7 @@ def get_zdim(da, errors="warn", **kwargs):
     --------
     get_dims
     """
-    dims = get_dims(da, "z", errors=errors)
+    dims = get_cf_dims(da, "z", errors=errors)
     if dims:
         return dims[0]
 
@@ -552,7 +553,7 @@ def get_tdim(da, errors="warn", **kwargs):
     --------
     get_dims
     """
-    dims = get_dims(da, "t", errors=errors)
+    dims = get_cf_dims(da, "t", errors=errors)
     if dims:
         return dims[0]
 
@@ -582,7 +583,7 @@ def get_fdim(da, errors="warn", **kwargs):
     --------
     get_dims
     """
-    dims = get_dims(da, "f", errors=errors)
+    dims = get_cf_dims(da, "f", errors=errors)
     if dims:
         return dims[0]
 
@@ -863,7 +864,7 @@ def get_positive_attr(da, zdim=None):
     """
     # Targets
     if zdim is None:
-        zdim = get_dims(da, "z", errors="ignore")
+        zdim = get_cf_dims(da, "z", errors="ignore")
         if zdim:
             zdim = zdim[0]
     if zdim and zdim in da.coords:
@@ -882,3 +883,24 @@ def get_positive_attr(da, zdim=None):
     # Fall back to current CFSpecs
     cfspecs = xcf.get_cf_specs(da)
     return cfspecs["vertical"]["positive"]
+
+
+def get_binding_data_vars(ds, coord, as_names=False):
+    """Get the data_vars that have this coordinate
+
+    Parameters
+    ----------
+    ds: xarray.Dataset
+    coord_name: str
+
+    Return
+    ------
+    list
+        List of data_var names
+    """
+    if not isinstance(coord, str):
+        coord = coord.name
+    out = [da for da in ds if coord in da.coords]
+    if as_names:
+        out = [da.name for da in out]
+    return out

--- a/xoa/grid.py
+++ b/xoa/grid.py
@@ -388,7 +388,7 @@ def dz2depth(
         a valid positive attribute.
     zdim: str
         Name of the vertical dimension.
-        If note set, it is infered with :func:`~xoa.coords.get_dims`.
+        If note set, it is infered with :func:`~xoa.coords.get_cf_dims`.
     ref: xarray.DataArray
         Reference array converting layer thicknesses to depth:
 
@@ -426,7 +426,7 @@ def dz2depth(
     """
     # Vertical dimension
     if zdim is None:
-        zdim = xcoords.get_dims(dz, "z", errors="raise")[0]
+        zdim = xcoords.get_zdim(dz, errors="raise")
 
     # Positive attribute
     positive = xcoords.positive_attr[positive].name
@@ -472,7 +472,7 @@ def dz2depth(
 
     # Finalize
     depth.attrs["positive"] = positive
-    depth = cfspecs.format_coord(depth, "depth")
+    depth = cfspecs.format_coord(depth, "depth", rename=False, format_coords=False)
 
     return depth
 
@@ -511,7 +511,7 @@ def decode_cf_dz2depth(ds, errors="raise", **kwargs):
     dz = cfspecs.search(ds, 'dz', errors=errors)
     if dz is None:
         return ds
-    zdims = xcoords.get_dims(dz, "z", errors=errors)
+    zdims = xcoords.get_cf_dims(dz, "z", errors=errors)
     if zdims is None:
         return ds
     zdim = zdims[0]

--- a/xoa/misc.py
+++ b/xoa/misc.py
@@ -563,9 +563,11 @@ def dict_merge(*dd, mergesubdicts=True, mergelists=False, mergetuples=False,
         for key, val in d.items():
             if skipnones and val is None:
                 continue
+
             # Not set so we set
             if key not in outd or (overwriteempty and is_empty(outd[key])):
                 outd[key] = val
+
             # Merge subdict
             elif (
                 mergesubdicts
@@ -573,6 +575,7 @@ def dict_merge(*dd, mergesubdicts=True, mergelists=False, mergetuples=False,
                 and isinstance(val, dict)
             ):
                 outd[key] = dict_merge(outd[key], val, **kwargs)
+
             # Merge lists
             elif (
                 mergelists
@@ -582,6 +585,7 @@ def dict_merge(*dd, mergesubdicts=True, mergelists=False, mergetuples=False,
                 outd[key] += val
                 if uniquify:
                     outd[key] = gunique(list(outd[key]))
+
             # Merge tuples
             elif (
                 mergetuples
@@ -608,6 +612,8 @@ def dict_merge(*dd, mergesubdicts=True, mergelists=False, mergetuples=False,
 
 def is_empty(x):
     """Check if empty"""
+    if isinstance(x, bool):
+        return False
     try:
         return not bool(x)
     except Exception:

--- a/xoa/regrid.py
+++ b/xoa/regrid.py
@@ -148,7 +148,9 @@ def regrid1d(
     cfspecs_out = xcf.get_cf_specs(coord)
     # - dim out
     if dim_out is None:  # get dim_out from coord_out
-        dim_out, dim_type = cfspecs_out.search_dim(coord, errors="raise")
+        dim_dict = cfspecs_out.search_dim(coord, errors="raise")
+        dim_out = dim_dict["dim"]
+        dim_type = dim_dict["type"]
     else:  # dim_out is provided
         dim_type = cfspecs_out.coords.get_dim_type(dim_out, coord)
     # - dim in

--- a/xoa/tests/test_cf.py
+++ b/xoa/tests/test_cf.py
@@ -31,8 +31,7 @@ def test_cf_sglocator_parse_attr(attr, value, expected):
 @pytest.mark.parametrize(
     "attr,value,expected",
     [
-        ("standard_name", "my_var_at_t_location",
-          ("my_var_at_t_location", None)),
+        ("standard_name", "my_var_at_t_location", ("my_var_at_t_location", None)),
         ("standard_name", "my_var_at_u_location", ("my_var", "u")),
         ("long_name", "My var at RHO location", ("My var", "rho")),
         ("long_name", "My var at rho location", ("My var", "rho")),
@@ -40,23 +39,27 @@ def test_cf_sglocator_parse_attr(attr, value, expected):
     ],
 )
 def test_cf_sglocator_parse_attr_with_valid_locations(attr, value, expected):
-    assert cf.SGLocator(valid_locations=['u', 'rho'],
-                        name_format="{root}{loc}",
-                        ).parse_attr(attr, value) == expected
+    assert (
+        cf.SGLocator(
+            valid_locations=['u', 'rho'],
+            name_format="{root}{loc}",
+        ).parse_attr(attr, value)
+        == expected
+    )
 
 
 @pytest.mark.parametrize(
     "name,standard_name,long_name,loc",
     [
-      ("u_t", None, None, "t"),
-      (None, "u_at_t_location", None, "t"),
-      (None, None, "U at T location", "t"),
-      ("u_t", "_at_t_location", "U at T location", "t"),
-      ("u", "u_at_t_location", None, "t"),
-      ("u", "u", "U", None)
-      ],
-    )
-def test_cf_sglocator_get_location(name, standard_name, long_name, loc):
+        ("u_t", None, None, "t"),
+        (None, "u_at_t_location", None, "t"),
+        (None, None, "U at T location", "t"),
+        ("u_t", "_at_t_location", "U at T location", "t"),
+        ("u", "u_at_t_location", None, "t"),
+        ("u", "u", "U", None),
+    ],
+)
+def test_cf_sglocator_get_loc_from_da(name, standard_name, long_name, loc):
 
     da = xr.DataArray(0)
     if name:
@@ -66,20 +69,20 @@ def test_cf_sglocator_get_location(name, standard_name, long_name, loc):
     if long_name:
         da.attrs["long_name"] = long_name
 
-    parsed_loc = cf.SGLocator().get_location(da)
+    parsed_loc = cf.SGLocator().get_loc_from_da(da)
     assert parsed_loc == loc
 
 
 @pytest.mark.parametrize(
     "name,standard_name,long_name",
     [
-      ("u_t", "u_at_u_location", None),
-      (None, "u_at_t_location", "U at U location"),
-      ("u_u", None, "U at T location"),
-      ("u_u", "u_at_w_location", "U at T location"),
-      ],
-    )
-def test_cf_sglocator_get_location_error(name, standard_name, long_name):
+        ("u_t", "u_at_u_location", None),
+        (None, "u_at_t_location", "U at U location"),
+        ("u_u", None, "U at T location"),
+        ("u_u", "u_at_w_location", "U at T location"),
+    ],
+)
+def test_cf_sglocator_get_loc_from_da_error(name, standard_name, long_name):
 
     da = xr.DataArray(0)
     if name:
@@ -90,7 +93,9 @@ def test_cf_sglocator_get_location_error(name, standard_name, long_name):
         da.attrs["long_name"] = long_name
 
     with pytest.raises(cf.XoaCFError):
-        cf.SGLocator().get_location(da)
+        cf.SGLocator().get_loc_from_da(da, errors="raise")
+
+    cf.SGLocator().get_loc_from_da(da, errors="ignore")
 
 
 @pytest.mark.parametrize(
@@ -132,7 +137,10 @@ def test_cf_sglocator_format_attr(attr, root, loc, expected):
 def test_cf_sglocator_format_attr_valid_locations():
     with pytest.raises(cf.XoaCFError) as excinfo:
         cf.SGLocator(valid_locations="x").format_attr("name", "banana", "y")
-    assert str(excinfo.value) == "Invalid location: y. Please one use of: x."
+    assert str(excinfo.value) == (
+        'Location "y" is not recognised by the currents '
+        'specifications. Registered locations are: x'
+    )
 
 
 def test_cf_sglocator_format_attrs_no_loc():
@@ -172,16 +180,16 @@ def test_cf_sglocator_format_attrs_with_loc():
 @pytest.mark.parametrize(
     "value0, value1, loc, value",
     [
-      ("sst", None, "t", "sst_t"),
-      (None, "sst", "t", "sst_t"),
-      ("sst", "sss", "t", "sss_t"),
-      ("sst_x", "sss_y", "t", "sss_t"),
-      ("sst_t", None, None, "sst_t"),
-      (None, "sst_t", None, "sst_t"),
-      ("sst_x", "sss_y", None, "sss_y"),
-      ("sst_x", "sss", None, "sss_x"),
-      ("sst", "sss_y", None, "sss_y"),
-      ]
+        ("sst", None, "t", "sst_t"),
+        (None, "sst", "t", "sst_t"),
+        ("sst", "sss", "t", "sss_t"),
+        ("sst_x", "sss_y", "t", "sss_t"),
+        ("sst_t", None, None, "sst_t"),
+        (None, "sst_t", None, "sst_t"),
+        ("sst_x", "sss_y", None, "sss_y"),
+        ("sst_x", "sss", None, "sss_x"),
+        ("sst", "sss_y", None, "sss_y"),
+    ],
 )
 def test_cf_sglocator_merge_attr(value0, value1, loc, value):
     out = cf.SGLocator().merge_attr("name", value0, value1, loc)
@@ -191,21 +199,17 @@ def test_cf_sglocator_merge_attr(value0, value1, loc, value):
 @pytest.mark.parametrize(
     "isn, psn, osn, loc, replace",
     [
-      ("sst", None, "sst", None, False),
-      (None, "sst", "sst", None, False),
-      ("sst", "temp", "sst", None, False),
-      ("sst", "temp", "temp", None, True),
-      ("sst_at_t_location", "temp_at_u_location", "sst_at_t_location",
-        None, False),
-      ("sst_at_t_location", "temp_at_u_location", "temp_at_u_location",
-        None, True),
-      ("sst", "temp", "sst_at_u_location", "u", False),
-      ("sst", "temp", "temp_at_u_location", "u", True),
-      ("sst_at_t_location", "temp_at_x_location", "sst_at_u_location",
-        "u", False),
-      ("sst_at_t_location", "temp_at_x_location", "temp_at_u_location",
-        "u", True),
-      ]
+        ("sst", None, "sst", None, False),
+        (None, "sst", "sst", None, False),
+        ("sst", "temp", "sst", None, False),
+        ("sst", "temp", "temp", None, True),
+        ("sst_at_t_location", "temp_at_u_location", "sst_at_t_location", None, False),
+        ("sst_at_t_location", "temp_at_u_location", "temp_at_u_location", None, True),
+        ("sst", "temp", "sst_at_u_location", "u", False),
+        ("sst", "temp", "temp_at_u_location", "u", True),
+        ("sst_at_t_location", "temp_at_x_location", "sst_at_u_location", "u", False),
+        ("sst_at_t_location", "temp_at_x_location", "temp_at_u_location", "u", True),
+    ],
 )
 def test_cf_sglocator_patch_attrs(isn, psn, osn, loc, replace):
 
@@ -216,8 +220,7 @@ def test_cf_sglocator_patch_attrs(isn, psn, osn, loc, replace):
     if psn:
         patch["standard_name"] = psn
 
-    oattrs = cf.SGLocator().patch_attrs(
-        iattrs, patch, loc=loc, replace=replace)
+    oattrs = cf.SGLocator().patch_attrs(iattrs, patch, loc=loc, replace=replace)
 
     assert oattrs["units"] == ("cm" if replace else "m")
     assert oattrs["color"] == "blue"
@@ -230,22 +233,26 @@ def test_cf_sglocator_patch_attrs(isn, psn, osn, loc, replace):
 @pytest.mark.parametrize(
     "floc,fname,fattrs,out_name,out_standard_name,replace_attrs",
     [
-      # ("p", None, None, "banana_p", "banana_at_p_location", False),
-      # (None, None, None, "banana_t", "banana", False),
-      ("p", "sst", {"standard_name": "potatoe"},
-      "sst_p", "banana_at_p_location", False),
-      ("p", "sst", {"standard_name": "potatoe"},
-      "sst_p", "potatoe_at_p_location", True),
-      ('x', "sst", {"standard_name": ["potatoe", "banana"]},
-      "sst_x", "banana_at_x_location", True),
-      (None, "sst_q", {"standard_name": ["potatoe"]},
-      "sst_q", "potatoe_at_q_location", True),
-      (None, "sst", {"standard_name": ["potatoe"]},
-      "sst_t", "potatoe_at_t_location", True)
-      ]
+        # ("p", None, None, "banana_p", "banana_at_p_location", False),
+        # (None, None, None, "banana_t", "banana", False),
+
+        # ("p", "sst", {"standard_name": "potatoe"}, "sst_p", "banana_at_p_location", False),
+        # ("p", "sst", {"standard_name": "potatoe"}, "sst_p", "potatoe_at_p_location", True),
+        # (
+        #     'x',
+        #     "sst",
+        #     {"standard_name": ["potatoe", "banana"]},
+        #     "sst_x",
+        #     "banana_at_x_location",
+        #     True,
+        # ),
+        (None, "sst_q", {"standard_name": ["potatoe"]}, "sst_q", "potatoe_at_q_location", True),
+        # (None, "sst", {"standard_name": ["potatoe"]}, "sst_t", "potatoe_at_t_location", True),
+    ],
 )
 def test_cf_sglocator_format_dataarray(
-        floc, fname, fattrs, out_name, out_standard_name, replace_attrs):
+    floc, fname, fattrs, out_name, out_standard_name, replace_attrs
+):
 
     lon = xr.DataArray(range(5), dims="lon")
     banana = xr.DataArray(
@@ -256,25 +263,22 @@ def test_cf_sglocator_format_dataarray(
         attrs={"standard_name": "banana", "taste": "good"},
     )
     banana_fmt = cf.SGLocator().format_dataarray(
-        banana, floc, name=fname, attrs=fattrs, replace_attrs=replace_attrs)
+        banana, loc=floc, name=fname, attrs=fattrs, replace_attrs=replace_attrs
+    )
     assert banana_fmt.name == out_name
     assert banana_fmt.standard_name == out_standard_name
     assert banana_fmt.taste == "good"
 
 
 def test_cf_sglocator_format_dataarray_no_copy_no_rename():
-    banana = xr.DataArray(1, name="banana_t",
-                          attrs={"standard_name": "banana"})
-    banana_fmt = cf.SGLocator().format_dataarray(
-        banana, "p", copy=False, rename=False)
+    banana = xr.DataArray(1, name="banana_t", attrs={"standard_name": "banana"})
+    banana_fmt = cf.SGLocator().format_dataarray(banana, "p", copy=False, rename=False)
     assert banana_fmt is banana
     assert banana_fmt.name == "banana_t"
     assert banana_fmt.standard_name == "banana_at_p_location"
 
 
-@pytest.mark.parametrize(
-    "cache", ["ignore", "write", "rw", "read", "ignore", "clean", "rw"]
-)
+@pytest.mark.parametrize("cache", ["ignore", "write", "rw", "read", "ignore", "clean", "rw"])
 def test_cf_get_cfg_specs(cache):
     assert isinstance(cf.get_cf_specs(cache=cache), cf.CFSpecs)
 
@@ -325,14 +329,9 @@ def test_cf_cfspecs_copy():
     cfspecs0 = cf.get_cf_specs()
     cfspecs1 = cfspecs0.copy()
     assert id(cfspecs0._dict) != id(cfspecs1._dict)
-    assert sorted(list(cfspecs0._dict["data_vars"])) == sorted(
-        list(cfspecs1._dict["data_vars"])
-    )
+    assert sorted(list(cfspecs0._dict["data_vars"])) == sorted(list(cfspecs1._dict["data_vars"]))
     assert cfspecs0._dict["coords"] == cfspecs1._dict["coords"]
-    assert (
-        cfspecs0._dict["data_vars"]["temp"]
-        == cfspecs1._dict["data_vars"]["temp"]
-    )
+    assert cfspecs0._dict["data_vars"]["temp"] == cfspecs1._dict["data_vars"]["temp"]
     assert "temp" in cfspecs1["data_vars"]
     assert "temperature" in cfspecs1["data_vars"]["temp"]["alt_names"]
 
@@ -356,17 +355,10 @@ def test_cf_set_cf_specs_context():
     assert cf.get_cf_specs() is cfspecs0
 
 
-@pytest.mark.parametrize(
-    "specialize,expected",
-    [
-          (False, "temp"),
-          (True, "temperature")
-      ]
-)
+@pytest.mark.parametrize("specialize,expected", [(False, "temp"), (True, "temperature")])
 def test_cf_cfspecs_get_name(specialize, expected):
     cfspecs = cf.CFSpecs({"data_vars": {"temp": {"name": "temperature"}}})
-    assert (cfspecs.data_vars.get_name("temp", specialize=specialize)
-            == expected)
+    assert cfspecs.data_vars.get_name("temp", specialize=specialize) == expected
 
 
 def test_cf_cfspecs_get_attrs():
@@ -374,6 +366,36 @@ def test_cf_cfspecs_get_attrs():
     attrs = cfspecs.data_vars.get_attrs("temp", other="ok")
     assert attrs["long_name"] == "Temperature"
     assert attrs["other"] == "ok"
+
+
+def test_cf_cfspecs_get_loc_mapping():
+
+    cf_dict0 = {
+        "sglocator": {
+            "valid_locations": ["u", "v"],
+        },
+        "data_vars": {
+            "u": {
+                "loc": "u",
+                "add_loc": False,
+                "add_coords_loc": {"lon": True, "x": True},
+            },
+            "bathy": {"add_loc": True},
+        },
+    }
+    cf_specs0 = cf.CFSpecs(cf_dict0)
+
+    ds0 = xr.Dataset(
+        {"u": (("time", "y", "x"), np.ones((1, 2, 3))), "bathy": (("y", "x"), np.ones((2, 3)))},
+        coords={
+            "lon": (("y", "x"), np.ones((2, 3))),
+            "lat": (("y", "x"), np.ones((2, 3))),
+            "time": ("time", [1]),
+        },
+    )
+
+    locations = cf_specs0.get_loc_mapping(ds0)
+    assert locations == {'u': False, 'lon': 'u', 'x': 'u', 'bathy': 'u', 'lat': None}
 
 
 @pytest.mark.parametrize("cf_name", [None, "lon"])
@@ -409,9 +431,8 @@ def test_cf_cfspecs_match_coord(cf_name, in_name, in_attrs):
 def test_cf_cfspecs_search_coord(cf_name, in_name, in_attrs):
 
     lon = xr.DataArray(range(5), dims=in_name, name=in_name, attrs=in_attrs)
-    temp = xr.DataArray(range(20, 25), dims=in_name,
-                        coords={in_name: lon}, name='temp')
-    res = cf.get_cf_specs().search_coord(temp, cf_name, get="name")
+    temp = xr.DataArray(range(20, 25), dims=in_name, coords={in_name: lon}, name='temp')
+    res = cf.get_cf_specs().search_coord(temp, cf_name, get="cf_name")
     assert res == 'lon'
 
 
@@ -426,8 +447,9 @@ def test_cf_cfspecs_search_coord(cf_name, in_name, in_attrs):
 def test_cf_cfspecs_match_data_var(cf_name, in_name, in_attrs):
 
     lon = xr.DataArray(range(5), dims='lon', name='lon')
-    temp = xr.DataArray(range(20, 25), dims='lon', coords={'lon': lon},
-                        name=in_name, attrs=in_attrs)
+    temp = xr.DataArray(
+        range(20, 25), dims='lon', coords={'lon': lon}, name=in_name, attrs=in_attrs
+    )
     res = cf.get_cf_specs().match_data_var(temp, cf_name)
     if cf_name is None:
         assert res == 'temp'
@@ -446,11 +468,50 @@ def test_cf_cfspecs_match_data_var(cf_name, in_name, in_attrs):
 def test_cf_cfspecs_search_data_var(cf_name, in_name, in_attrs):
 
     lon = xr.DataArray(range(5), dims='lon', name='lon')
-    temp = xr.DataArray(range(20, 25), dims='lon', coords={'lon': lon},
-                        name=in_name, attrs=in_attrs)
+    temp = xr.DataArray(
+        range(20, 25), dims='lon', coords={'lon': lon}, name=in_name, attrs=in_attrs
+    )
     ds = temp.to_dataset()
-    assert cf.get_cf_specs().search_data_var(
-        ds, cf_name, get="name") == 'temp'
+    assert cf.get_cf_specs().search_data_var(ds, cf_name, get="cf_name") == 'temp'
+
+
+def test_cf_cfspecs_cats_get_loc_arg():
+
+    cf_dict0 = {
+        "sglocator": {
+            "valid_locations": ["u", "v"],
+        },
+        "data_vars": {
+            "u": {
+                "loc": "u",
+                "add_loc": False,
+                "add_coords_loc": {"lon": True},
+            },
+        },
+    }
+    cf_specs0 = cf.CFSpecs(cf_dict0)
+
+    ds0 = xr.Dataset(
+        {"u": (("time", "y", "x"), np.ones((1, 2, 3))), "bathy": (("y", "x"), np.ones((2, 3)))},
+        coords={
+            "lon": (("y", "x"), np.ones((2, 3))),
+            "lat": (("y", "x"), np.ones((2, 3))),
+            "time": ("time", [1]),
+        },
+    )
+
+    assert cf_specs0.coords.get_loc_arg(ds0["u"]) is None
+    assert cf_specs0.coords.get_loc_arg(ds0["bathy"]) is None
+    assert cf_specs0.coords.get_loc_arg(ds0["lon"]) is None
+
+    locations0 = cf_specs0.get_loc_mapping(ds0)
+    assert cf_specs0.coords.get_loc_arg(ds0["lon"], locations=locations0) == "u"
+
+    cf_dict1 = cf_dict0.copy()
+    cf_dict1["data_vars"]["u"]["add_coords_loc"]["lon"] = "v"
+    cf_specs1 = cf.CFSpecs(cf_dict1)
+    locations1 = cf_specs1.get_loc_mapping(ds0)
+    assert cf_specs1.coords.get_loc_arg(ds0["lon"], locations=locations1) == "v"
 
 
 @pytest.mark.parametrize("cf_name", [None, "lon"])
@@ -462,25 +523,63 @@ def test_cf_cfspecs_search_data_var(cf_name, in_name, in_attrs):
         ("xxx", {"units": "degrees_east"}),
     ],
 )
-def test_cf_cfspecs_format_coord(cf_name, in_name, in_attrs):
+def test_cf_cfspecs_cats_format_dataarray(cf_name, in_name, in_attrs):
 
     lon = xr.DataArray(range(5), dims=in_name, name=in_name, attrs=in_attrs)
-    lon = cf.get_cf_specs().format_coord(lon, cf_name)
+    lon = cf.get_cf_specs().coords.format_dataarray(lon, cf_name)
     assert lon.name == "lon"
     assert lon.standard_name == "longitude"
     assert lon.long_name == "Longitude"
     assert lon.units == "degrees_east"
 
 
-def test_cf_cfspecs_format_coord_unknown():
+def test_cf_cfspecs_cats_format_dataarray_unknown():
     coord = xr.DataArray(range(5), name='foo')
     cfspecs = cf.get_cf_specs()
 
-    coord_fmt = cfspecs.format_coord(coord, rename=False)
+    coord_fmt = cfspecs.coords.format_dataarray(coord, rename=False)
     assert coord_fmt is None
 
-    coord_fmt = cfspecs.format_coord(coord, rename=True)
+    coord_fmt = cfspecs.coords.format_dataarray(coord, rename=True)
     assert coord_fmt.name == "foo"
+
+
+def test_cf_cfspecs_cats_get_allowed_names():
+    cfg = {"data_vars": {"banana": {"name": "bonono", "alt_names": ["binini", "bununu"]}}}
+    cfspecs = cf.CFSpecs(cfg)
+    assert cfspecs.data_vars.get_allowed_names("banana") == ['banana', 'bonono', 'binini', 'bununu']
+
+
+def test_cf_cfspecs_format_obj_with_loc():
+
+    cf_dict0 = {
+        "sglocator": {
+            "valid_locations": ["u", "v"],
+        },
+        "data_vars": {
+            "u": {
+                "loc": "u",
+                "add_loc": False,
+                "add_coords_loc": {"lon": True, "x": True},
+            },
+            "bathy": {"add_loc": True},
+        },
+    }
+    cf_specs0 = cf.CFSpecs(cf_dict0)
+
+    ds0 = xr.Dataset(
+        {"u": (("time", "y", "x"), np.ones((1, 2, 3))), "bathy": (("y", "x"), np.ones((2, 3)))},
+        coords={
+            "lon": (("y", "x"), np.ones((2, 3))),
+            "lat": (("y", "x"), np.ones((2, 3))),
+            "time": ("time", [1]),
+        },
+    )
+    ds = cf_specs0.format_dataset(ds0)
+    assert "x_u" in ds.dims
+    assert "y" in ds.dims
+    assert "u" in ds
+    assert "bathy_u" in ds
 
 
 @pytest.mark.parametrize("cf_name", [None, "temp"])
@@ -488,15 +587,15 @@ def test_cf_cfspecs_format_coord_unknown():
     "in_name,in_attrs",
     [
         ("temp", None),
-        ("xxx", {"standard_name": "sea_water_temperature"}),
+        ("yyy", {"standard_name": "sea_water_temperature"}),
     ],
 )
 def test_cf_cfspecs_format_data_var(cf_name, in_name, in_attrs):
 
-    lon = xr.DataArray(range(5), dims='xxx', name='xxx',
-                        attrs={'standard_name': 'longitude'})
-    temp = xr.DataArray(range(20, 25), dims='xxx', coords={'xxx': lon},
-                        name=in_name, attrs=in_attrs)
+    lon = xr.DataArray(range(5), dims='xxx', name='xxx', attrs={'standard_name': 'longitude'})
+    temp = xr.DataArray(
+        range(20, 25), dims='xxx', coords={'xxx': lon}, name=in_name, attrs=in_attrs
+    )
     temp = cf.get_cf_specs().format_data_var(temp, cf_name)
     assert temp.name == "temp"
     assert temp.standard_name == "sea_water_temperature"
@@ -508,6 +607,8 @@ def test_cf_cfspecs_format_data_var(cf_name, in_name, in_attrs):
 def test_cf_cfspecs_format_data_var_coord():
     da = xr.DataArray(0, attrs={'standard_name': 'longitude_at_u_location'})
     da = cf.get_cf_specs().format_data_var(da)
+
+
 #     assert da.name == "lon_u"
 
 
@@ -526,10 +627,7 @@ def test_cf_cfspecs_format_data_var_loc():
 
     temp_fmt = cfspecs.format_data_var(temp, "temp", format_coords=False, replace_attrs=True)
     assert temp_fmt.name == "temp"
-    assert temp_fmt.standard_name == "sea_water_temperature_at_x_location"
-
-    temp_fmt = cfspecs.format_data_var(temp, "temp", format_coords=False, replace_attrs=True, add_loc_to_name=True)
-    assert temp_fmt.name == "temp_x"
+    assert temp_fmt.standard_name == "sea_water_temperature"  #_at_x_location"
 
     cfspecs = cf.CFSpecs({"data_vars": {"temp": {"add_loc": True}}})
     temp_fmt = cfspecs.format_data_var(temp, "temp", format_coords=False, replace_attrs=True)
@@ -541,11 +639,42 @@ def test_cf_cfspecs_format_data_var_unkown():
     cfspecs = cf.get_cf_specs()
 
     da_fmt = cfspecs.format_data_var(da, rename=False)
-    assert da_fmt is None
+    assert da_fmt.name == "foo"
 
     da_fmt = cfspecs.format_data_var(da, rename=True)
     assert da_fmt.name == "foo"
 
+
+def test_cf_cfspecs_to_loc():
+    ds = xr.Dataset(
+        {"u_t": (("time", "y", "x_u"), np.ones((1, 2, 3)))},
+        coords={
+            "lon_u": (("y", "x_u"), np.ones((2, 3))),
+            "lat": (("y", "x_u"), np.ones((2, 3))),
+            "time": ("time", [1]),
+        },
+    )
+    cfspecs = cf.get_cf_specs()
+    dso = cfspecs.to_loc(ds, x=False, y='v', u=None)
+    assert "x" in dso.dims
+    assert "y_v" in dso.dims
+    assert "u_t" in dso
+    assert "lon_u" in dso
+
+def test_cf_cfspecs_reloc():
+    ds = xr.Dataset(
+        {"u_t": (("time", "y", "x_u"), np.ones((1, 2, 3)))},
+        coords={
+            "lon_u": (("y", "x_u"), np.ones((2, 3))),
+            "lat": (("y", "x_u"), np.ones((2, 3))),
+            "time": ("time", [1]),
+        },
+    )
+    cfspecs = cf.get_cf_specs()
+    dso = cfspecs.reloc(ds, u=False, t='u')
+    assert "x" in dso.dims
+    assert "u_u" in dso
+    assert "lon" in dso
 
 def test_cf_cfspecs_coords_get_axis():
     cfspecs = cf.get_cf_specs().coords
@@ -555,8 +684,7 @@ def test_cf_cfspecs_coords_get_axis():
     assert cfspecs.get_axis(depth) == 'Z'
 
     # from CF specs
-    depth = xr.DataArray([1], dims='aa',
-                          attrs={'standard_name': 'ocean_layer_depth'})
+    depth = xr.DataArray([1], dims='aa', attrs={'standard_name': 'ocean_layer_depth'})
     assert cfspecs.get_axis(depth) == 'Z'
 
 
@@ -570,70 +698,74 @@ def test_cf_cfspecs_coords_get_dim_type():
     # from a known coordinate
     coord = xr.DataArray([1], dims='aa', attrs={'standard_name': 'longitude'})
     da = xr.DataArray([1], dims='aa', coords={'aa': coord})
-    assert cfspecs.get_dim_type('aa', da=da) == "x"
+    assert cfspecs.get_dim_type('aa', da) == "x"
 
 
 def test_cf_cfspecs_coords_get_dim_types():
     cfspecs = cf.get_cf_specs().coords
 
     aa = xr.DataArray([0, 1], dims="aa", attrs={"standard_name": "latitude"})
-    da = xr.DataArray(np.ones((2, 2, 2)), dims=('foo', 'aa', 'xi'),
-                      coords={'aa': aa})
+    da = xr.DataArray(np.ones((2, 2, 2)), dims=('foo', 'aa', 'xi'), coords={'aa': aa})
 
     assert cfspecs.get_dim_types(da) == (None, 'y', 'x')
     assert cfspecs.get_dim_types(da, unknown='-') == ("-", 'y', 'x')
-    assert cfspecs.get_dim_types(da, asdict=True) == {
-        "foo": None, "aa": "y", "xi": "x"}
+    assert cfspecs.get_dim_types(da, asdict=True) == {"foo": None, "aa": "y", "xi": "x"}
 
 
 def test_cf_cfspecs_coords_search_dim():
     cfspecs = cf.get_cf_specs().coords
 
     # from name
-    temp = xr.DataArray(np.arange(2*3).reshape(1, 2, 3),
-                        dims=('aa', 'ny', 'x'))
+    temp = xr.DataArray(np.arange(2 * 3).reshape(1, 2, 3), dims=('aa', 'ny', 'x'))
     assert cfspecs.search_dim(temp, 'y') == 'ny'
-    assert cfspecs.search_dim(temp) == (None, None)
+    assert cfspecs.search_dim(temp) is None
 
     # from explicit axis attribute
     depth = xr.DataArray([1], dims='aa', attrs={'axis': 'z'})
     temp.coords['aa'] = depth
     assert cfspecs.search_dim(temp, 'z') == 'aa'
-    assert cfspecs.search_dim(temp) == (None, None)
-    assert cfspecs.search_dim(depth) == ("aa", "z")
+    assert cfspecs.search_dim(temp) is None
+    assert cfspecs.search_dim(depth) == {"dim": "aa", "type": "z", "cf_name": None}
 
     # from known coordinate
     del temp.coords['aa'].attrs['axis']
     temp.coords['aa'].attrs['standard_name'] = 'ocean_layer_depth'
     assert cfspecs.search_dim(temp, 'z') == 'aa'
-    assert cfspecs.search_dim(temp) == (None, None)
+    assert cfspecs.search_dim(temp, 'depth') == 'aa'  # by generic name
+    assert cfspecs.search_dim(temp) is None
 
     # subcoords
     level = xr.DataArray(np.arange(2), dims='level')
-    depth = xr.DataArray(np.arange(2*3).reshape(2, 3),
-                          dims=('level', 'lon'), name='depth',
-                          coords={'level': level,
-                                  'lon': [3, 4, 5]})
-    assert cfspecs.search_dim(depth) == ('level', 'z')
-    assert cfspecs.search_dim(depth.level) == ('level', 'z')
+    depth = xr.DataArray(
+        np.arange(2 * 3).reshape(2, 3),
+        dims=('level', 'lon'),
+        name='depth',
+        coords={'level': level, 'lon': [3, 4, 5]},
+    )
+    assert cfspecs.search_dim(depth) == {'dim': 'level', 'cf_name': 'level', 'type': 'z'}
+    assert cfspecs.search_dim(depth.level) == {'dim': 'level', 'type': 'z', 'cf_name': 'level'}
     depth = depth.rename(level='aa')
     depth.aa.attrs['axis'] = 'Z'
-    assert cfspecs.search_dim(depth) == ('aa', 'z')
+    assert cfspecs.search_dim(depth) == {'dim': 'aa', 'type': 'z', 'cf_name': None}
 
     # not found but only 1d and no dim_type specified
-    assert cfspecs.search_dim(xr.DataArray([5], dims='bb')) == ('bb', None)
+    assert cfspecs.search_dim(xr.DataArray([5], dims='bb')) == {
+        'dim': 'bb',
+        'type': None,
+        'cf_name': None,
+    }
 
 
 def test_cf_cfspecs_coords_search_from_dim():
 
     lon = xr.DataArray([1, 2], dims='lon')
-    level = xr.DataArray(
-        [1, 2, 3], dims='aa', attrs={'standard_name': 'ocean_sigma_coordinate'})
+    level = xr.DataArray([1, 2, 3], dims='aa', attrs={'standard_name': 'ocean_sigma_coordinate'})
     mem = xr.DataArray(range(3), dims='mem')
     temp = xr.DataArray(
         np.zeros((mem.size, level.size, lon.size)),
         dims=('mem', 'aa', 'lon'),
-        coords={'mem': mem, 'aa': level, 'lon': lon})
+        coords={'mem': mem, 'aa': level, 'lon': lon},
+    )
 
     cfspecs = cf.get_cf_specs().coords
 
@@ -642,14 +774,14 @@ def test_cf_cfspecs_coords_search_from_dim():
 
     # Depth coordinate because the only one with this dim
     depth = xr.DataArray(
-        np.ones((level.size, lon.size)), dims=('aa', 'lon'), coords={'aa': level, 'lon': lon})
+        np.ones((level.size, lon.size)), dims=('aa', 'lon'), coords={'aa': level, 'lon': lon}
+    )
     temp.coords['depth'] = depth
     assert cfspecs.search_from_dim(temp, 'aa').name == 'depth'
 
     # Cannot get dim_type and we have multiple coords with this dim
     del temp.coords['aa']
-    fake = xr.DataArray(
-        np.ones((level.size, lon.size)), dims=('aa', 'lon'), coords={'lon': lon})
+    fake = xr.DataArray(np.ones((level.size, lon.size)), dims=('aa', 'lon'), coords={'lon': lon})
     temp.coords['fake'] = fake
     assert cfspecs.search_from_dim(temp, 'aa') is None
 
@@ -665,8 +797,9 @@ def test_cf_cfspecs_coords_search_from_dim():
 def test_cf_cfspecs_coords_get_dims():
     lat = xr.DataArray([4, 5], dims='yy', attrs={'units': 'degrees_north'})
     depth = xr.DataArray([4, 5], dims='level', attrs={'axis': 'Z'})
-    da = xr.DataArray(np.ones((2, 2, 2, 2)), dims=('r', 'level', 'yy', 'xi'),
-                      coords={'level': depth, 'yy': lat})
+    da = xr.DataArray(
+        np.ones((2, 2, 2, 2)), dims=('r', 'level', 'yy', 'xi'), coords={'level': depth, 'yy': lat}
+    )
 
     cfspecs = cf.get_cf_specs().coords
     dims = cfspecs.get_dims(da, 'xyzt', allow_positional=True)
@@ -676,8 +809,7 @@ def test_cf_cfspecs_coords_get_dims():
 
 
 def test_cf_cfspecs_infer_coords():
-    ds = xr.Dataset({"temp": ("nx", [1, 2]),
-                      "lon": ("nx", [4, 5])})
+    ds = xr.Dataset({"temp": ("nx", [1, 2]), "lon": ("nx", [4, 5])})
     ds = cf.get_cf_specs().infer_coords(ds)
     assert "lon" in ds.coords
 
@@ -688,14 +820,46 @@ def test_cf_cfspecs_decode_encode():
 
     dsc = cfspecs.decode(ds)
     assert list(dsc) == [
-        'akt', 'cs_r', 'cs_w', 'Vtransform', 'angle', 'el', 'corio',
-        'bathy', 'hbl', 'hc', 'mask_rho', 'ex', 'ey', 'sal',
-        'sc_r', 'sc_w', 'ptemp', 'time_step', 'u', 'v', 'w', 'xl', 'ssh']
+        'akt',
+        'cs_r',
+        'cs_w',
+        'Vtransform',
+        'angle',
+        'el',
+        'corio',
+        'bathy',
+        'hbl',
+        'hc',
+        'mask_rho',
+        'ex',
+        'ey',
+        'sal',
+        'sc_r',
+        'sc_w',
+        'ptemp',
+        'time_step',
+        'u',
+        'v',
+        'w',
+        'xl',
+        'ssh',
+    ]
     assert list(dsc.coords) == [
-        'y_rho', 'y_v', 'lat_rho', 'lat_u', 'lat_v', 'lon_rho', 'lon_u', 'lon_v',
-        'sig_rho', 'sig_w', 'time', 'x_rho', 'x_u']
-    assert list(dsc.dims) == [
-        'auxil', 'sig_rho', 'sig_w', 'time', 'x_rho', 'x_u', 'y_rho', 'y_v']
+        'y_rho',
+        'y_v',
+        'lat_rho',
+        'lat_u',
+        'lat_v',
+        'lon_rho',
+        'lon_u',
+        'lon_v',
+        'sig_rho',
+        'sig_w',
+        'time',
+        'x_rho',
+        'x_u',
+    ]
+    assert set(dsc.dims) == {'auxil', 'sig_rho', 'sig_w', 'time', 'x_rho', 'x_u', 'y_rho', 'y_v'}
 
     dse = cfspecs.encode(dsc)
     assert list(dse) == list(ds)
@@ -706,16 +870,13 @@ def test_cf_cfspecs_decode_encode():
 
 def test_cf_dataarraycfaccessor():
     from xoa.accessors import CFDataArrayAccessor
+
     with warnings.catch_warnings():
-        warnings.simplefilter(
-            "ignore",
-            xr.core.extensions.AccessorRegistrationWarning)
+        warnings.simplefilter("ignore", xr.core.extensions.AccessorRegistrationWarning)
         xr.register_dataarray_accessor('xcf')(CFDataArrayAccessor)
 
-    lon = xr.DataArray(range(5), dims='xxx', name='xxx',
-                        attrs={'standard_name': 'longitude'})
-    temp = xr.DataArray(range(20, 25), dims='xxx',
-                        coords={'xxx': lon}, name='temp')
+    lon = xr.DataArray(range(5), dims='xxx', name='xxx', attrs={'standard_name': 'longitude'})
+    temp = xr.DataArray(range(20, 25), dims='xxx', coords={'xxx': lon}, name='temp')
 
     assert temp.xcf.lon.name == 'xxx'
     assert temp.xcf.lat is None
@@ -724,17 +885,19 @@ def test_cf_dataarraycfaccessor():
 
 def test_cf_datasetcfaccessor():
     from xoa.accessors import CFDatasetAccessor
+
     with warnings.catch_warnings():
-        warnings.simplefilter(
-            "ignore",
-            xr.core.extensions.AccessorRegistrationWarning)
+        warnings.simplefilter("ignore", xr.core.extensions.AccessorRegistrationWarning)
         xr.register_dataset_accessor('xcf')(CFDatasetAccessor)
 
-    lon = xr.DataArray(range(5), dims='xxx', name='xxx',
-                        attrs={'standard_name': 'longitude'})
-    temp = xr.DataArray(range(20, 25), dims='xxx',
-                        coords={'xxx': lon}, name='yoyo',
-                        attrs={'standard_name': 'sea_water_temperature'})
+    lon = xr.DataArray(range(5), dims='xxx', name='xxx', attrs={'standard_name': 'longitude'})
+    temp = xr.DataArray(
+        range(20, 25),
+        dims='xxx',
+        coords={'xxx': lon},
+        name='yoyo',
+        attrs={'standard_name': 'sea_water_temperature'},
+    )
 
     ds = temp.to_dataset()
     assert ds.xcf.temp.name == 'yoyo'
@@ -802,19 +965,20 @@ def test_cf_get_cf_specs_from_encoding():
     cf.register_cf_specs(cf_specs_in)
 
     ds = xr.Dataset(
-          {"mytemp": (["mylat", "mylon"], np.ones((2, 2))),
-          "mysal": (["mylat", "mylon"], np.ones((2, 2)))},
-          coords={"mylon": np.arange(2),
-                  "mylat": np.arange(2)}
-          )
+        {
+            "mytemp": (["mylat", "mylon"], np.ones((2, 2))),
+            "mysal": (["mylat", "mylon"], np.ones((2, 2))),
+        },
+        coords={"mylon": np.arange(2), "mylat": np.arange(2)},
+    )
 
-    ds.encoding.update(cfspecs="mynam234")
+    ds.encoding.update(cf_specs="mynam234")
     assert cf.get_cf_specs_from_encoding(ds) is cf_specs_in
 
-    ds.mytemp.encoding.update(cfspecs="mynam234")
+    ds.mytemp.encoding.update(cf_specs="mynam234")
     assert cf.get_cf_specs_from_encoding(ds.mytemp) is cf_specs_in
 
-    ds.mylon.encoding.update(cfspecs="mynam234")
+    ds.mylon.encoding.update(cf_specs="mynam234")
     assert cf.get_cf_specs_from_encoding(ds.mylon) is cf_specs_in
 
     assert cf.get_cf_specs_from_encoding(ds.mylat) is None
@@ -868,11 +1032,12 @@ def test_cf_get_cf_specs_matching_score():
     cf_specs2 = cf.CFSpecs(cf_content2)
 
     ds = xr.Dataset(
-          {"mytemp": (["mylat", "mylon"], np.ones((2, 2))),
-          "mysal": (["mylat", "mylon"], np.ones((2, 2)))},
-          coords={"mylon": np.arange(2),
-                  "mylat": np.arange(2)}
-          )
+        {
+            "mytemp": (["mylat", "mylon"], np.ones((2, 2))),
+            "mysal": (["mylat", "mylon"], np.ones((2, 2))),
+        },
+        coords={"mylon": np.arange(2), "mylat": np.arange(2)},
+    )
 
     for cf_specs, score in [(cf_specs0, 25), (cf_specs1, 75), (cf_specs2, 50)]:
         assert cf.get_cf_specs_matching_score(ds, cf_specs) == score
@@ -927,8 +1092,31 @@ def test_cf_infer_cf_specs():
     ds.attrs.update(source="my hycom3d!")
     assert cf.infer_cf_specs(ds) is cf_specs0
 
-    ds.attrs.update(cfspecs="hycom3d")
+    ds.attrs.update(cf_specs="hycom3d")
     assert cf.infer_cf_specs(ds) is cf_specs2
+
 
 # test_cf_cfspecs_decode_encode()
 # test_cf_cfspecs_format_data_var_loc()
+# test_cf_cfspecs_coords_get_loc_arg()
+# test_cf_cfspecs_format_obj_with_loc()
+# test_cf_cfspecs_get_loc_mapping()
+# test_cf_cfspecs_coords_search_dim()
+
+# lon = xr.DataArray(range(5), dims="lon")
+# banana = xr.DataArray(
+#     lon + 20,
+#     dims="lon",
+#     coords=[lon],
+#     name="banana_t",
+#     attrs={"standard_name": "banana", "taste": "good"},
+# )
+# floc, fname, fattrs, out_name, out_standard_name, replace_attrs=None, "sst_q", {"standard_name": ["potatoe"]}, "sst_q", "potatoe_at_q_location", True
+# print(cf.SGLocator().format_dataarray(
+#     banana, loc=floc, name=fname, attrs=fattrs, replace_attrs=replace_attrs
+# ))
+
+# sg = cf.SGLocator()
+# print(sg.get_loc(name="u_t", attrs=dict(standard_name = None, long_name = None)))
+
+# test_cf_cfspecs_decode_encode()


### PR DESCRIPTION
Add:
- the loc+add_loc+add_coords_loc options and sections in CF config
- the to_loc and reloc CFSpecs methods
- support of dimension name argument to search_dim
- the boolstr cfgm validator

Fixes:
- dz2depth output formatting

Breaking changes:
- now most of cf methods use cf_name instead of name argument
- get_dims is renamed to get_cf_dims in coords and accepts cf_args as argument
- cf search_dim new return a dict if no cf_name is provided