### PR TITLE
Fix choose of sigma coordinates

### DIFF
--- a/xoa/sigma.py
+++ b/xoa/sigma.py
@@ -538,14 +538,9 @@ def get_sigma_terms(ds, vloc=None, hlocs=None, rename=False):
                 "No standard_name attribute found in sigma/s " "variable name: " + sig.name
             )
         standard_name, loc = cfspecs.sglocator.parse_attr("standard_name", sig.standard_name)
+        #skip this one
         if standard_name not in SIGMA_COORDINATE_TYPES:
-            raise XoaSigmaError(
-                "Sigma/s coordinate not supported: "
-                + standard_name
-                + ". Supported coordinates: "
-                + " ".join(SIGMA_COORDINATE_TYPES)
-            )
-
+           continue
         # Get formula terms
         if "formula_terms" not in sig.attrs:
             raise XoaSigmaError(


### PR DESCRIPTION
fix issue https://github.com/VACUMM/xoa/issues/57#issue-1156654649

In case of multiples *levels* coordinates detected, silently ignore the one that dont have standard name in **SIGMA_COORDINATE_TYPES**