### PR TITLE
Fix/cf to meta migration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@ Deprecations
 
 Bug fixes
 ---------
+- Remove the ``xoa reset_cf_cache`` CLI command: the disk cache no longer exists in :mod:`xoa.meta` and the command was raising :exc:`AttributeError` at runtime [:pull:`117`].
 - Fix :func:`xoa.coords.get_time` that was returning None.
 - Fix :func:`xoa.interp.linear1d` extrapolation [:pull:`107`]
 - Fix :func:`xoa.grid.to_rect` warnings.

--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -37,13 +37,3 @@ Print only info about paths:
 .. command-output:: xoa info paths
 
 
-:command:`xoa reset_cf_cache`
-=============================
-
-.. argparse::
-    :module: xoa.cli
-    :func: get_parser
-    :prog: xoa
-    :path: reset_cf_cache
-
-

--- a/tests/test_cf.py
+++ b/tests/test_cf.py
@@ -1027,13 +1027,13 @@ def test_cf_get_meta_specs_from_encoding():
         coords={"mylon": np.arange(2), "mylat": np.arange(2)},
     )
 
-    ds.encoding.update(cf_specs="mynam234")
+    ds.encoding.update(meta_specs="mynam234")
     assert meta.get_meta_specs_from_encoding(ds) is cf_specs_in
 
-    ds.mytemp.encoding.update(cf_specs="mynam234")
+    ds.mytemp.encoding.update(meta_specs="mynam234")
     assert meta.get_meta_specs_from_encoding(ds.mytemp) is cf_specs_in
 
-    ds.mylon.encoding.update(cf_specs="mynam234")
+    ds.mylon.encoding.update(meta_specs="mynam234")
     assert meta.get_meta_specs_from_encoding(ds.mylon) is cf_specs_in
 
     assert meta.get_meta_specs_from_encoding(ds.mylat) is None

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -56,3 +56,9 @@ class TestOptionsManagement:
         options.reset_options()
         default = options.get_option('plot.cmapdiv')
         assert 'balance' in default.lower() or default == options.get_option('plot.cmapdiv')
+
+    def test_meta_cache_option(self):
+        """Test that the meta.cache option exists and defaults to False"""
+        value = options.get_option('meta.cache')
+        assert isinstance(value, bool)
+        assert value is False

--- a/xoa/accessors.py
+++ b/xoa/accessors.py
@@ -359,7 +359,7 @@ class _MetaCoordAccessor_(_MetaAccessor_):
 
     @property
     def dim(self):
-        from .cf import XoaError
+        from .exceptions import XoaError
 
         try:
             return self._meta_specs.coords.search_dim(self._obj)[0]
@@ -611,7 +611,7 @@ class SigmaAccessor(_BasicMetaAccessor_):
         dict, dict of dict
             A dict is generated for a given sigma variable,
             whose keys are array names, like ``"sc_r"``,
-            and values are :mod:`~xoa.cf` names, like ``"sig"``.
+            and values are :mod:`~xoa.meta` names, like ``"sig"``.
             A special key is the ``"type"`` whose corresponding value
             is the ``standard_name``, stripped from its potential staggered grid
             location indicator.

--- a/xoa/cli.py
+++ b/xoa/cli.py
@@ -37,9 +37,6 @@ def get_parser(formatter_class=argparse.ArgumentDefaultsHelpFormatter):
     )
     parser_info.set_defaults(func=main_info)
 
-    parser_reset_cf_cache = subparsers.add_parser('reset_cf_cache', help='remove the CF cache file')
-    parser_reset_cf_cache.set_defaults(func=main_reset_cf_cache)
-
     return parser
 
 
@@ -62,9 +59,3 @@ def main_info(parser, args):
         options.show_options()
 
 
-def main_reset_cf_cache(parser, args):
-    """Handle the ``reset_cf_cache`` subcommand"""
-    from . import cf
-
-    cf.reset_cache(disk=True)
-    print("Removed CF cache file: " + cf.USER_CF_CACHE_FILE)

--- a/xoa/meta/general.py
+++ b/xoa/meta/general.py
@@ -164,7 +164,7 @@ class MetaSpecs(categories._MetaBase_):
 
         # Get it from cache if from str or MetaSpecs with registration name
         if cache is None:
-            cache = options.get_option("cf.cache")
+            cache = options.get_option("meta.cache")
         cache = cache and (
             (isinstance(cfg, str) and "\n" not in cfg)
             or (isinstance(cfg, dict) and "register" in cfg and cfg["register"]["name"])

--- a/xoa/meta/sglocator.py
+++ b/xoa/meta/sglocator.py
@@ -126,7 +126,7 @@ class SGLocator(object):
         .. ipython:: python
 
             @suppress
-            from xoa.cf import SGLocator
+            from xoa.meta.sglocator import SGLocator
             sg = SGLocator(name_format="{root}_{loc}")
             sg.parse_attr("name", "super_banana_t")
             sg.parse_attr("standard_name", "super_banana_at_rhum_location")
@@ -327,7 +327,7 @@ class SGLocator(object):
         .. ipython:: python
 
             @suppress
-            from xoa.cf import SGLocator
+            from xoa.meta.sglocator import SGLocator
             sg = SGLocator()
             sg.format_attr('standard_name', 'sea_water_temperature', 't')
             sg.format_attr('standard_name', 'sea_water_temperature', False)
@@ -388,7 +388,7 @@ class SGLocator(object):
         .. ipython:: python
 
             @suppress
-            from xoa.cf import SGLocator
+            from xoa.meta.sglocator import SGLocator
             sg = SGLocator()
             attrs = dict(standard_name='sea_water_temperature_at_t_location',
                          long_name='sea_water_temperature',
@@ -432,7 +432,7 @@ class SGLocator(object):
         .. ipython:: python
 
             @suppress
-            from xoa.cf import SGLocator
+            from xoa.meta.sglocator import SGLocator
             sg = SGLocator()
             sg.merge_attr('name', 'temp_t', 'mytemp')
             sg.merge_attr('name', 'temp', 'mytemp_t')

--- a/xoa/options.py
+++ b/xoa/options.py
@@ -28,8 +28,8 @@ _RE_OPTION_MATCH = re.compile(r"^(\w+)\W(\w+)$").match
 
 #: Specifications of configuration options
 CONFIG_SPECS = """
-[cf] # cf module
-cache=boolean(default=False) # use the :mod:`~xoa.cf` in memory and file caches
+[meta] # meta module
+cache=boolean(default=False) # use the :mod:`~xoa.meta` in memory cache
 
 [plot] # plot parameters
 cmapdiv = string(default="cmo.balance") # default diverging colormap

--- a/xoa/plot.py
+++ b/xoa/plot.py
@@ -34,7 +34,7 @@ import cartopy.feature as cfeature
 from . import exceptions
 from . import misc as xmisc
 from . import geo as xgeo
-from . import cf as xcf
+from . import meta as xmeta
 from . import coords as xcoords
 from . import dyn
 
@@ -288,10 +288,10 @@ def plot_ts(
     """
 
     # Potential temperature
-    cfspecs = xcf.get_cf_specs(temp)
+    metaspecs = xmeta.get_meta_specs(temp)
     # potential = POTENTIAL[potential]
     if potential is None:
-        potential = cfspecs.match_data_var(temp, "ptemp")
+        potential = metaspecs.match_data_var(temp, "ptemp")
 
     if not potential:
         import gsw
@@ -303,7 +303,7 @@ def plot_ts(
             pres = gsw.p_from_z(depth, lat)
 
         if absolute is None:
-            absolute = cfspecs.match_data_var(sal, "asal")
+            absolute = metaspecs.match_data_var(sal, "asal")
         if not absolute:
             lon = xcoords.get_lon(temp)
             lat = xcoords.get_lat(temp)
@@ -314,7 +314,7 @@ def plot_ts(
         attrs = temp.attrs
         temp = gsw.pt0_from_t(sal_abs, temp, pres)
         temp.attrs.update(attrs)
-        cfspecs.format_data_var(temp, meta_name="ptemp", copy=False, replace_attrs=True)
+        metaspecs.format_data_var(temp, meta_name="ptemp", copy=False, replace_attrs=True)
 
     # Init plot
     axes = kwargs.get("ax", axes)
@@ -366,7 +366,7 @@ def plot_ts(
         lon_m = xcoords.get_lon(temp).mean()
         lat_m = xcoords.get_lat(temp).mean()
         if absolute is None:
-            absolute = cfspecs.match_data_var(sal, "asal")
+            absolute = metaspecs.match_data_var(sal, "asal")
         if not absolute:
             ss_absolute = gsw.SA_from_SP(ss, 0, lon_m.values, lat_m.values)
         else:


### PR DESCRIPTION
# Description

Complete the migration from `xoa.cf` to `xoa.meta` by removing residual references to the deprecated module. The backward-compatibility shims (`xoa/cf.py`, `xoa/cf_configs.py`) remain intentionally in place.

Changes:
- Rename config section `[cf]` → `[meta]` in `options.py` and update the corresponding option key in `meta/general.py`
- Remove the `reset_cf_cache` CLI command and its documentation (`cli.py`, `doc/cli.rst`): the disk cache no longer exists in `xoa.meta`, making the command a no-op that also raised `AttributeError` at runtime
- Replace `xoa.cf` import with `xoa.meta` in `plot.py`
- Fix `XoaError` import in `accessors.py` to use its canonical source (`xoa.exceptions`) and update a stale docstring reference
- Fix four docstring examples in `meta/sglocator.py` that imported `SGLocator` from the deprecated module
- Fix encoding key `cf_specs` → `meta_specs` in three test assertions in `tests/test_cf.py`

# Check list

- [x] Closes #117
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `CHANGES.rst`
- [ ] New modules are listed in `api.rst`